### PR TITLE
feat: integrate espeak tts pipeline and multi-client lipsync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
-# stickbot 项目的环境变量示例文件
-# 请复制为 .env 并填入真实的服务端凭证或配置。
-
-# Express 服务监听端口
-STICKBOT_SERVER_PORT=8787
-
-# 真实 TTS 服务的 API Endpoint（占位示例）
-TTS_API_ENDPOINT=https://example.com/tts
-
-# 真实 LLM 服务的 API 密钥（请勿提交到仓库）
-LLM_API_KEY=your-llm-api-key
+# stickbot 配置示例，复制为 .env 后根据实际环境调整。
+TTS_PROVIDER=espeak
+ESPEAK_CMD=espeak-ng
+ESPEAK_VOICE=zh
+ESPEAK_RATE=170
+TMP_DIR=./tmp
+AZURE_REGION=
+AZURE_KEY=
+# 可选：自定义 mouth 采样率与口型映射
+# MOUTH_SAMPLE_RATE=80
+# VISEME_CONFIG_PATH=./viseme.custom.json
+# CORS_WHITELIST=https://example.com

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,12 @@ yarn-error.log*
 .pnpm-debug.log*
 .DS_Store
 .tmp/
+tmp/
 coverage/
+
+# WeChat mini program build cache
+weapp-stickbot/miniprogram/
+weapp-stickbot/dist/
 
 # Editor directories and files
 .idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "express": "^4.19.2"
       },
       "devDependencies": {
@@ -476,6 +477,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:web": "http-server web -p 5173 -c-1",
     "dev:server": "node server/server.js",
     "dev": "npm-run-all --parallel dev:web dev:server",
-    "lint": "node --check server/server.js web/js/main.js web/js/avatar.js web/js/lipsync.js"
+    "lint": "node --check server/server.js web/js/main.js web/js/avatar.js web/js/lipsync.js",
+    "clean:tmp": "node --input-type=module -e \"import fs from 'fs'; fs.rmSync('tmp', { recursive: true, force: true }); fs.mkdirSync('tmp', { recursive: true });\""
   },
   "keywords": [
     "stickbot",
@@ -18,6 +19,7 @@
   "author": "stickbot maintainers",
   "license": "MIT",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.19.2"
   },
   "devDependencies": {

--- a/server/README.md
+++ b/server/README.md
@@ -1,59 +1,162 @@
-# 服务端占位实现说明
+# stickbot 服务端（第二轮）
 
-本目录提供最小可运行的 Express 服务，用于支撑 stickbot 前端的回退策略，并作为后续对接真实 AI 能力的骨架。
+本目录提供可运行的 Express 服务，接入 eSpeak NG 命令行，实现真实的语音合成与口型时间轴。服务端将音频写入临时目录，并通过 `/audio/:id` 提供下载。
 
-## 当前接口
+## 快速启动
 
-- `POST /chat`：回显传入的 `messages` 数组，仅作占位演示。
-- `GET /tts`：返回文本说明，提示开发者接入真实 TTS 并提供口型时间轴。
+```bash
+# 安装依赖
+npm install
 
-## 接入真实 TTS 的步骤
+# 复制环境变量示例
+cp .env.example .env
 
-1. **选择服务商**：可考虑 Azure Cognitive Services、科大讯飞、火山引擎、ElevenLabs 等，确保其 SDK 支持获取 viseme/phoneme 时间轴或至少提供音频流访问。
-2. **在 `/tts` 中调用 TTS API**：
-   - 将 `req.query.text` 作为合成文本。
-   - 将音频缓存在对象存储/CDN，得到 `audioUrl`。
-   - 从 TTS 回调或辅助算法中获得口型时间轴。
-3. **构造响应**：
+# 启动服务端（默认监听 8787）
+npm run dev:server
+```
+
+> 若需要同时启动网页端，可运行 `npm run dev`，该命令会并行启动 `http-server` 与本服务端。
+
+## 环境变量说明
+
+| 变量名 | 默认值 | 说明 |
+| --- | --- | --- |
+| `TTS_PROVIDER` | `espeak` | 默认 TTS 供应器，可选 `espeak` 或 `azure`（需额外配置）。 |
+| `ESPEAK_CMD` | `espeak-ng` | eSpeak NG 命令行名称或绝对路径。 |
+| `ESPEAK_VOICE` | `zh` | 默认发音人，可填 `en-US`、`cmn` 等。 |
+| `ESPEAK_RATE` | `170` | 默认语速（WPM），与 `espeak-ng -s` 参数一致。 |
+| `TMP_DIR` | `./tmp` | 运行期临时目录，存放 `.wav` 与 `.pho`。 |
+| `MOUTH_SAMPLE_RATE` | `80` | mouth 时间轴采样频率（Hz），建议 60–100。 |
+| `CORS_WHITELIST` | 空 | 生产环境域名白名单，逗号分隔。 |
+| `AZURE_REGION` | 空 | Azure 语音服务区域。 |
+| `AZURE_KEY` | 空 | Azure 语音服务密钥。 |
+| `VISEME_CONFIG_PATH` | 空 | 自定义口型映射 JSON 路径。 |
+
+更多变量可参考根目录的 `.env.example`。
+
+## eSpeak NG 安装指引
+
+- **macOS**：`brew install espeak` 或 `brew install espeak-ng`
+- **Ubuntu/Debian**：`sudo apt install espeak-ng`
+- **Windows**：可通过 [winget](https://learn.microsoft.com/windows/package-manager/winget/) 安装 `espeak-ng`，或使用官方发行版，安装后将 `espeak-ng.exe` 加入 `PATH`。
+
+服务端会调用如下命令生成音频与 `.pho` 文件：
+
+```bash
+espeak-ng -v zh -s 170 --pho --phonout tmp/<id>.pho -w tmp/<id>.wav "你好 stickbot"
+```
+
+## `.pho` 文件解析
+
+`.pho` 是 MBROLA 控制文件，行格式形如：
+
+```
+; comment
+sh 16 90
+an 20 100
+```
+
+- 第一列为音素（phoneme）。
+- 第二列为时长，单位为 **10ms**。
+- 后续列为基频控制点，此处可忽略。
+
+服务端会：
+
+1. 读取每一行的音素与时长，并按顺序累计成时间轴。
+2. 将音素映射为口型编号（viseme）。
+3. 根据采样率（默认 80Hz）生成稀疏关键帧，最终返回给前端。
+
+## 口型映射（默认值）
+
+### 音素 → 口型编号
+
+| 口型 ID | 示例音素 | 说明 |
+| --- | --- | --- |
+| 0 | `p`、`b`、`m` | 闭唇爆破音 |
+| 1 | `f`、`v` | 唇齿半开 |
+| 2 | `t`、`d`、`s`、`z` | 齿龈接触 |
+| 3 | `r`、`zh`、`ch`、`sh` | 卷舌/儿化 |
+| 4 | `e`、`ə` | 中开央元音 |
+| 5 | `o`、`ɔ`、`ŋ` | 中开圆唇 |
+| 6 | `i`、`j`、`y` | 扁唇高元音 |
+| 7 | `æ` | 大开前元音 |
+| 8 | `a`、`ɑ` | 最大开口 |
+| 9 | `u`、`ʊ` | 圆唇收紧 |
+
+可通过 `VISEME_CONFIG_PATH` 指向自定义 JSON（包含 `phonemeToViseme` 与 `visemeToMouth` 字段）覆盖上述映射，适配更多语种。
+
+### 口型编号 → mouth 数值
+
+| 口型 ID | 默认 mouth |
+| --- | --- |
+| 0 | 0.05 |
+| 1 | 0.22 |
+| 2 | 0.32 |
+| 3 | 0.40 |
+| 4 | 0.52 |
+| 5 | 0.60 |
+| 6 | 0.45 |
+| 7 | 0.70 |
+| 8 | 0.92 |
+| 9 | 0.62 |
+
+mouth 值范围为 `[0,1]`，前端按照线性插值驱动“大嘴巴”头像的唇形、牙齿与嘴角角度。
+
+## Azure 适配示例
+
+若需要启用 Azure 语音服务：
+
+1. 安装 SDK：`npm install microsoft-cognitiveservices-speech-sdk`
+2. 在 `.env` 中配置 `AZURE_REGION` 与 `AZURE_KEY`。
+3. 将 `TTS_PROVIDER` 设置为 `azure`。
+4. `server/src/tts/adapters/AzureAdapter.js` 中演示了如何监听 `VisemeReceived` 事件，并将 `audioOffset`（纳秒）转换为秒。
+
+> 默认不会加载 Azure 适配器；若未安装 SDK 或未配置密钥，请保持 `TTS_PROVIDER=espeak`。
+
+## API 说明
+
+### `GET /tts`
+
+请求参数：
+
+- `text`（必填）：要合成的文本。
+- `voice`（可选）：覆盖默认发音人。
+- `rate`（可选）：语速（WPM），与 `espeak-ng -s` 对齐。
+- `provider`（可选）：`espeak` 或 `azure`。
+
+返回示例：
 
 ```json
 {
-  "audioUrl": "https://your-cdn/path/tts.mp3",
+  "audioUrl": "/audio/0f1d.wav",
+  "audioType": "audio/wav",
   "mouthTimeline": [
-    { "t": 0.00, "v": 0.00 },
-    { "t": 0.08, "v": 0.85 },
-    { "t": 0.16, "v": 0.20 }
-  ]
+    { "t": 0, "v": 0.05, "visemeId": 0, "phoneme": "sil" },
+    { "t": 0.0125, "v": 0.32, "visemeId": 2, "phoneme": "t" }
+  ],
+  "duration": 1.84,
+  "provider": "espeak",
+  "sampleRate": 80
 }
 ```
 
-- `t` 为秒，`v` 为 0~1 的口型开合度。
-- 若服务端可提供更精细的 viseme 序列，可进一步扩展字段。
+前端会优先使用 `mouthTimeline`；若数组为空，会退回到 Web Speech 或音量包络分析。
 
-## viseme → mouth 映射建议
+### `GET /audio/:id`
 
-| Viseme | 描述 | mouth 建议值 |
-| --- | --- | --- |
-| `sil` | 静音或闭口 | `0.0` |
-| `a` / `aa` | 张大嘴 | `0.9` |
-| `e` / `i` | 扁平嘴型 | `0.5` |
-| `u` / `o` | 圆唇 | `0.7` |
-| `m` / `b` / `p` | 双唇闭合 | `0.1` |
+下载运行期生成的 WAV 音频。文件会在 30 分钟后自动清理，可通过 `TMP_FILE_TTL_MS` 自定义过期时间。
 
-可对相邻点应用线性插值或样条插值，生成平滑的 `mouthTimeline`。
+### `POST /chat`
 
-## CDN 与缓存建议
+仍保留占位逻辑，便于后续接入真实对话模型。
 
-- 将生成的音频文件上传到支持 HTTPS 的对象存储（如 OSS、COS、S3），通过 CDN 加速跨区域访问。
-- 根据文本与语音参数计算哈希，命中缓存时直接返回已生成的音频与时间轴，减少 TTS 调用成本。
-- 对敏感文本做好鉴黄与合法性检测，避免滥用。
+## CORS 与安全
 
-## 环境变量配置
+- 开发环境默认允许任意来源。若部署到公网，请在 `.env` 中设置 `CORS_ALLOW_ALL=false` 并配置 `CORS_WHITELIST`。
+- 音频文件存放于 `TMP_DIR`，服务端会每隔 5 分钟清理一次过期资源。
 
-- 在 `.env` 中新增 `TTS_API_ENDPOINT`、`TTS_API_KEY` 等字段。
-- 在 `server.js` 中读取并传递给实际的 TTS SDK，切勿硬编码密钥到前端。
+## 与多端协作
 
-## 与小程序/多端协作
+- 网页端会根据 `mouthTimeline` 驱动“大嘴巴头”动画，Sprite 模式依赖同名 viseme 贴图。
+- 微信小程序会使用 `/tts` 返回的时间轴，以 50–80ms 的间隔进行插值，保持与网页一致的口型效果。
 
-- 微信小程序不支持 Web Speech，必须依赖服务端时间轴。确保 `/tts` 同时返回 `audioUrl` 与 `mouthTimeline`。
-- 如果需要多语种支持，可在请求中加入 `lang`/`voice` 等参数，由服务端统一处理。

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -1,0 +1,96 @@
+/**
+ * @file config.js
+ * @description 读取 stickbot 服务端的运行配置，涵盖 TTS 供应商、临时目录与口型映射等信息。
+ *              由于项目坚持轻量化，这里不引入复杂的配置框架，而是以环境变量 + 默认值组合实现。
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadVisemeConfig, DEFAULT_VISEME_CONFIG } from './tts/mapping.js';
+
+/** @typedef {import('./tts/mapping.js').VisemeConfig} VisemeConfig */
+
+/**
+ * 解析项目根目录路径，便于在任何工作目录下都能正确定位 tmp/、配置文件等资源。
+ * Node.js 的 ESM 环境中没有 __dirname，这里通过 fileURLToPath 计算。
+ * @returns {string} 项目根目录的绝对路径。
+ */
+const resolveRootDir = () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  return path.resolve(__dirname, '..', '..');
+};
+
+/**
+ * 根据环境变量构建统一配置对象。
+ * @returns {{
+ *   port: number,
+ *   defaultProvider: 'espeak' | 'azure',
+ *   tmpDir: string,
+ *   cleanupIntervalMs: number,
+ *   cleanupTTL: number,
+ *   sampleRate: number,
+ *   espeak: {
+ *     command: string,
+ *     voice: string,
+ *     rate: number,
+ *   },
+ *   azure: {
+ *     region: string,
+ *     key: string,
+ *   },
+ *   visemeConfig: VisemeConfig,
+ *   cors: {
+ *     enabled: boolean,
+ *     allowAllOrigins: boolean,
+ *     whitelist: string[],
+ *   }
+ * }} 完整的服务端配置。
+ */
+export const loadServerConfig = async () => {
+  const rootDir = resolveRootDir();
+  const tmpDir = path.resolve(rootDir, process.env.TMP_DIR || './tmp');
+  const sampleRate = Number(process.env.MOUTH_SAMPLE_RATE || 80);
+
+  /**
+   * 若设置了自定义 viseme 映射文件，则尝试解析；
+   * 文件格式要求详见 server/README.md。读取失败时回退至默认映射。
+   */
+  const visemeConfig = loadVisemeConfig(process.env.VISEME_CONFIG_PATH, DEFAULT_VISEME_CONFIG);
+
+  return {
+    port: Number(process.env.STICKBOT_SERVER_PORT || 8787),
+    defaultProvider: /** @type {'espeak' | 'azure'} */ (process.env.TTS_PROVIDER || 'espeak'),
+    tmpDir,
+    cleanupIntervalMs: Number(process.env.TMP_SWEEP_INTERVAL_MS || 5 * 60 * 1000),
+    cleanupTTL: Number(process.env.TMP_FILE_TTL_MS || 30 * 60 * 1000),
+    sampleRate,
+    espeak: {
+      command: process.env.ESPEAK_CMD || 'espeak-ng',
+      voice: process.env.ESPEAK_VOICE || 'zh',
+      rate: Number(process.env.ESPEAK_RATE || 170),
+    },
+    azure: {
+      region: process.env.AZURE_REGION || '',
+      key: process.env.AZURE_KEY || '',
+    },
+    visemeConfig,
+    cors: {
+      enabled: process.env.CORS_ENABLED ? process.env.CORS_ENABLED === 'true' : true,
+      allowAllOrigins: process.env.CORS_ALLOW_ALL ? process.env.CORS_ALLOW_ALL === 'true' : process.env.NODE_ENV !== 'production',
+      whitelist: process.env.CORS_WHITELIST ? process.env.CORS_WHITELIST.split(',').map((item) => item.trim()).filter(Boolean) : [],
+    },
+  };
+};
+
+/**
+ * 确保临时目录存在，若不存在则自动创建。
+ * @param {string} tmpDir - 配置中指定的临时目录路径。
+ */
+export const ensureTmpDir = (tmpDir) => {
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  }
+};
+

--- a/server/src/tts/ITtsProvider.js
+++ b/server/src/tts/ITtsProvider.js
@@ -1,0 +1,37 @@
+/**
+ * @file ITtsProvider.js
+ * @description 约定 TTS 适配器统一接口，便于在路由层做策略分发。
+ */
+
+/**
+ * @typedef {Object} TtsSynthesizeOptions
+ * @property {string} [voice] - 发音人配置，具体取值与供应商相关。
+ * @property {number} [rate] - 语速，通常与供应商 CLI 或 SDK 参数一致。
+ */
+
+/**
+ * @typedef {Object} TtsSynthesizeResult
+ * @property {string} id - 本次生成的临时资源 ID，可由服务端拼接下载 URL。
+ * @property {string} audioPath - 音频文件绝对路径。
+ * @property {string} audioType - 音频 MIME 类型，如 `audio/wav`。
+ * @property {{ t: number, v: number, visemeId: number, phoneme?: string }[]} mouthTimeline - mouth 时间轴采样点。
+ * @property {number} duration - 音频总时长（秒）。
+ */
+
+/**
+ * @interface ITtsProvider
+ * @description 统一的 TTS 供应商接口规范，所有适配器都应实现 `synthesize` 方法。
+ */
+export class ITtsProvider {
+  // eslint-disable-next-line class-methods-use-this
+  /**
+   * 执行语音合成。
+   * @param {string} _text - 输入文本。
+   * @param {TtsSynthesizeOptions} [_options] - 可选参数。
+   * @returns {Promise<TtsSynthesizeResult>} 合成结果。
+   */
+  async synthesize(_text, _options) {
+    throw new Error('ITtsProvider 为抽象接口，请使用具体适配器实现。');
+  }
+}
+

--- a/server/src/tts/adapters/AzureAdapter.js
+++ b/server/src/tts/adapters/AzureAdapter.js
@@ -1,0 +1,122 @@
+/**
+ * @file AzureAdapter.js
+ * @description 演示如何接入 Azure Cognitive Services 的语音合成 SDK，包含 VisemeReceived 事件处理逻辑。
+ *              本文件不会在默认流程中执行，仅作为示例。启用前请确保安装 `microsoft-cognitiveservices-speech-sdk` 并配置密钥。
+ */
+
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { ensureTimelineFallback } from '../utils/timeline.js';
+
+/**
+ * @typedef {import('../mapping.js').VisemeConfig} VisemeConfig
+ */
+
+/**
+ * AzureAdapter 构造参数。
+ * @typedef {Object} AzureOptions
+ * @property {string} region - Azure 语音服务区域，例如 `eastasia`。
+ * @property {string} key - Azure 语音服务密钥。
+ * @property {string} tmpDir - 临时目录，用于写入生成的 WAV 文件。
+ * @property {VisemeConfig} visemeConfig - 音素映射配置，用于将 viseme ID 转换为 mouth 值。
+ */
+
+/**
+ * AzureAdapter 主要用于示例如何监听 VisemeReceived 事件以生成口型时间轴。
+ */
+export class AzureAdapter {
+  /**
+   * @param {AzureOptions} options - 构造参数。
+   */
+  constructor(options) {
+    this.region = options.region;
+    this.key = options.key;
+    this.tmpDir = options.tmpDir;
+    this.visemeConfig = options.visemeConfig;
+  }
+
+  /**
+   * 语音合成。实际项目需处理 SSML、语速等参数，这里仅给出示例。
+   * @param {string} text - 输入文本。
+   * @returns {Promise<import('../ITtsProvider.js').TtsSynthesizeResult>} 结果。
+   */
+  async synthesize(text) {
+    if (!this.region || !this.key) {
+      throw new Error('未配置 Azure 区域或密钥，无法启用 AzureAdapter。');
+    }
+
+    // 动态引入 SDK，避免在未安装依赖时打包失败。
+    let sdk;
+    try {
+      sdk = await import('microsoft-cognitiveservices-speech-sdk');
+    } catch (error) {
+      throw new Error('请先安装 `microsoft-cognitiveservices-speech-sdk` 依赖后再启用 Azure TTS。');
+    }
+
+    const speechConfig = sdk.SpeechConfig.fromSubscription(this.key, this.region);
+    speechConfig.speechSynthesisOutputFormat = sdk.SpeechSynthesisOutputFormat.Riff16Khz16BitMonoPcm;
+
+    const audioId = randomUUID();
+    const audioPath = path.join(this.tmpDir, `${audioId}.wav`);
+    const audioConfig = sdk.AudioConfig.fromAudioFileOutput(audioPath);
+    const synthesizer = new sdk.SpeechSynthesizer(speechConfig, audioConfig);
+
+    const timeline = [];
+    const start = Date.now();
+
+    /**
+     * Azure SDK 在 VisemeReceived 事件中提供 `animation` 字段，表示 viseme ID；
+     * `audioOffset` 为纳秒，需要转换为秒后再与 mouth 映射表匹配。
+     */
+    synthesizer.visemeReceived = (_s, event) => {
+      const seconds = Number(event.audioOffset) / 1e7; // 纳秒 -> 秒
+      const visemeId = Number(event.visemeId ?? event.viseme ?? 0);
+      const mouth = this.resolveMouthFromViseme(visemeId);
+      timeline.push({ t: seconds, v: mouth, visemeId, phoneme: `viseme-${visemeId}` });
+    };
+
+    await new Promise((resolve, reject) => {
+      synthesizer.speakTextAsync(
+        text,
+        () => {
+          synthesizer.close();
+          resolve();
+        },
+        (error) => {
+          synthesizer.close();
+          reject(error);
+        },
+      );
+    });
+
+    const duration = (Date.now() - start) / 1000;
+    return {
+      id: audioId,
+      audioPath,
+      audioType: 'audio/wav',
+      mouthTimeline: ensureTimelineFallback(timeline),
+      duration,
+    };
+  }
+
+  /**
+   * 根据 Azure 的 viseme ID 映射 mouth 值。Azure 的 viseme 与 eSpeak 不同，默认提供 22 个编号。
+   * 这里给出简单示例：如需精细化控制可在 README 中提示如何调整。
+   * @param {number} visemeId - Azure SDK 返回的口型编号。
+   * @returns {number} mouth 值。
+   */
+  resolveMouthFromViseme(visemeId) {
+    const mapping = {
+      0: 0.05,
+      1: 0.12,
+      2: 0.25,
+      3: 0.35,
+      4: 0.45,
+      5: 0.58,
+      6: 0.7,
+      7: 0.85,
+    };
+    return mapping[visemeId] ?? 0.3;
+  }
+}
+

--- a/server/src/tts/adapters/EspeakAdapter.js
+++ b/server/src/tts/adapters/EspeakAdapter.js
@@ -1,0 +1,158 @@
+/**
+ * @file EspeakAdapter.js
+ * @description 通过调用 eSpeak NG 命令行将文本转换为音频与 `.pho` 口型文件，并解析为统一时间轴。
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import { mapPhonemeToViseme } from '../mapping.js';
+import { accumulateSegments, ensureTimelineFallback, generateTimeline } from '../utils/timeline.js';
+
+/**
+ * @typedef {import('../mapping.js').VisemeConfig} VisemeConfig
+ * @typedef {import('../utils/timeline.js').MouthKeyframe} MouthKeyframe
+ */
+
+/**
+ * @typedef {Object} EspeakOptions
+ * @property {string} command - eSpeak NG 命令名称或绝对路径，默认 `espeak-ng`。
+ * @property {string} voice - 发音人 ID，例如 `zh`、`en-US`。
+ * @property {number} rate - 语速，单位为 WPM，与命令行 `-s` 参数一致。
+ * @property {string} tmpDir - 运行期临时目录，用于存放音频与 `.pho` 文件。
+ * @property {number} sampleRate - mouth 时间轴采样率（Hz），建议 60-100。
+ * @property {VisemeConfig} visemeConfig - 音素映射配置。
+ */
+
+/**
+ * @typedef {Object} SynthesizeOptions
+ * @property {string} [voice] - 可覆盖默认发音人。
+ * @property {number} [rate] - 可覆盖默认语速。
+ */
+
+/**
+ * @typedef {Object} EspeakResult
+ * @property {string} id - 临时文件 ID，可用于拼接下载地址。
+ * @property {string} audioPath - 音频文件在磁盘上的绝对路径。
+ * @property {string} audioType - 音频类型，当前固定为 `audio/wav`。
+ * @property {MouthKeyframe[]} mouthTimeline - 采样后的口型时间轴。
+ * @property {number} duration - 总时长（秒）。
+ */
+
+/**
+ * EspeakAdapter 负责封装 eSpeak NG 命令行调用及 `.pho` 解析流程。
+ */
+export class EspeakAdapter {
+  /**
+   * @param {EspeakOptions} options - 构造参数。
+   */
+  constructor(options) {
+    this.command = options.command;
+    this.voice = options.voice;
+    this.rate = options.rate;
+    this.tmpDir = options.tmpDir;
+    this.sampleRate = options.sampleRate;
+    this.visemeConfig = options.visemeConfig;
+  }
+
+  /**
+   * 执行一次语音合成。
+   * @param {string} text - 待合成的文本内容。
+   * @param {SynthesizeOptions} [options] - 可覆盖默认语速/发音人。
+   * @returns {Promise<EspeakResult>} 合成结果，包含音频路径与口型时间轴。
+   */
+  async synthesize(text, options = {}) {
+    if (!text || !text.trim()) {
+      throw new Error('文本不能为空。');
+    }
+    const trimmed = text.trim();
+    const voice = options.voice || this.voice;
+    const rate = options.rate || this.rate;
+    const id = randomUUID();
+    const wavPath = path.join(this.tmpDir, `${id}.wav`);
+    const phoPath = path.join(this.tmpDir, `${id}.pho`);
+
+    await this.runCommand(trimmed, { voice, rate, wavPath, phoPath });
+
+    const segments = this.parsePho(phoPath);
+    const { cumulative, totalDuration } = accumulateSegments(segments);
+    const timeline = ensureTimelineFallback(generateTimeline(cumulative, totalDuration, this.sampleRate));
+
+    // `.pho` 文件只在解析阶段使用，为避免目录堆积及时删除。
+    await fs.promises.unlink(phoPath).catch(() => {});
+
+    return {
+      id,
+      audioPath: wavPath,
+      audioType: 'audio/wav',
+      mouthTimeline: timeline,
+      duration: totalDuration,
+    };
+  }
+
+  /**
+   * 调用 eSpeak NG 命令行生成音频与 `.pho` 文件。
+   * @param {string} text - 输入文本。
+   * @param {{ voice: string, rate: number, wavPath: string, phoPath: string }} params - 命令执行参数。
+   * @returns {Promise<void>} 命令执行完成。
+   */
+  runCommand(text, params) {
+    const args = [
+      '-v',
+      params.voice,
+      '-s',
+      String(params.rate),
+      '--pho',
+      '--phonout',
+      params.phoPath,
+      '-w',
+      params.wavPath,
+      text,
+    ];
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.command, args, { stdio: 'ignore' });
+      child.on('error', (error) => {
+        reject(new Error(`无法调用 eSpeak NG，请确认命令是否安装并在 PATH 中。原始错误：${error.message}`));
+      });
+      child.on('exit', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`eSpeak NG 返回非零状态码：${code}`));
+        }
+      });
+    });
+  }
+
+  /**
+   * 解析 `.pho` 文件，将音素及时长转换为统一的口型片段。
+   * `.pho` 行格式通常为：`phoneme duration pitch1 pitch2 ...`，其中 duration 为 10ms 单位。
+   * @param {string} phoPath - `.pho` 文件绝对路径。
+   * @returns {Array<{ phoneme: string, durationMs: number, visemeId: number, mouth: number }>} 口型片段数组。
+   */
+  parsePho(phoPath) {
+    const content = fs.readFileSync(phoPath, 'utf-8');
+    const lines = content.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const segments = [];
+    for (const line of lines) {
+      if (line.startsWith(';')) {
+        continue; // 注释行
+      }
+      const parts = line.split(/\s+/);
+      if (parts.length < 2) {
+        continue;
+      }
+      const phoneme = parts[0];
+      const duration10ms = Number(parts[1]);
+      if (!Number.isFinite(duration10ms) || duration10ms <= 0) {
+        continue;
+      }
+      const durationMs = duration10ms * 10;
+      const { visemeId, mouth } = mapPhonemeToViseme(phoneme, this.visemeConfig);
+      segments.push({ phoneme, durationMs, visemeId, mouth });
+    }
+    return segments;
+  }
+}
+

--- a/server/src/tts/mapping.js
+++ b/server/src/tts/mapping.js
@@ -1,0 +1,158 @@
+/**
+ * @file mapping.js
+ * @description 定义音素（phoneme）到口型（viseme）的默认映射，并提供加载外部 JSON 配置的工具函数。
+ *              eSpeak NG 在输出 `.pho` 文件时会包含大量类似 `a 120 90` 的行，这些音素需要归一化为有限个口型类别。
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * @typedef {Object} VisemeConfig
+ * @property {Record<string, number>} phonemeToViseme - 音素到口型编号的映射表。
+ * @property {Record<string, number>} visemeToMouth - 口型编号到张嘴幅度（0-1）的映射。
+ * @property {Record<string, { description: string }>} [visemeMeta] - 口型额外描述，便于文档化。
+ */
+
+/**
+ * 默认口型配置，覆盖常见的中英文音素。
+ * 数值越大嘴巴越张开，部分圆唇音会带有额外的 UI 提示以收紧嘴角。
+ */
+export const DEFAULT_VISEME_CONFIG = {
+  phonemeToViseme: {
+    // 完全闭合类：双唇音，适合 /p b m/ 等。eSpeak 中文音素 b\", p\" 亦归此类。
+    p: 0,
+    b: 0,
+    m: 0,
+    'b\u02bc': 0,
+    'p\u02bc': 0,
+    'm\u02bc': 0,
+    'b\u02b0': 0,
+    'p\u02b0': 0,
+    'm\u02b0': 0,
+    'b=': 0,
+    'p=': 0,
+    'm=': 0,
+    // 半开类：唇齿音、舌尖音。
+    f: 1,
+    v: 1,
+    'f\u02bc': 1,
+    'f\u02b0': 1,
+    'v\u02bc': 1,
+    'v\u02b0': 1,
+    s: 2,
+    z: 2,
+    t: 2,
+    d: 2,
+    n: 2,
+    l: 2,
+    'ts': 2,
+    'dz': 2,
+    't\u0361s': 2,
+    'd\u0361z': 2,
+    r: 3,
+    'r\u02bc': 3,
+    'r=': 3,
+    'zh': 3,
+    'ch': 3,
+    'sh': 3,
+    'zh\u02bc': 3,
+    'ch\u02bc': 3,
+    'sh\u02bc': 3,
+    // 中度张口：央元音或开口度适中元音。
+    e: 4,
+    '\u0259': 4,
+    '\u025a': 4,
+    '\u0254': 5,
+    o: 5,
+    '\u0251': 8,
+    a: 8,
+    '\u00e6': 7,
+    '\u028c': 6,
+    '\u028a': 9,
+    u: 9,
+    '\u0289': 9,
+    '\u026f': 9,
+    i: 6,
+    j: 6,
+    y: 6,
+    'i\u02bc': 6,
+    'j\u02bc': 6,
+    'y\u02bc': 6,
+    // 鼻化或儿化音：与上文同一类，保持嘴巴半开并在前端可加上鼻腔震动特效。
+    '\u026b': 3,
+    '\u0272': 6,
+    '\u014b': 5,
+    'er': 3,
+    // 默认兜底：未知音素统一归为轻微张口，避免时间轴断裂。
+    default: 2,
+  },
+  visemeToMouth: {
+    0: 0.05,
+    1: 0.22,
+    2: 0.32,
+    3: 0.4,
+    4: 0.52,
+    5: 0.6,
+    6: 0.45,
+    7: 0.7,
+    8: 0.92,
+    9: 0.62,
+  },
+  visemeMeta: {
+    0: { description: '闭唇 /p b m/' },
+    1: { description: '唇齿半开 /f v/' },
+    2: { description: '齿龈轻触 /t d s z/' },
+    3: { description: '卷舌或儿化 /r ɚ/' },
+    4: { description: '中开央元音 /ə e/' },
+    5: { description: '中开圆唇 /o ɔ/' },
+    6: { description: '扁唇高元音 /i j y/' },
+    7: { description: '大幅开口前元音 /æ/' },
+    8: { description: '最大开口 /a ɑ/' },
+    9: { description: '圆唇高元音 /u ʊ/' },
+  },
+};
+
+/**
+ * 根据音素查找口型编号。
+ * @param {string} phoneme - eSpeak `.pho` 行中的音素字符串。
+ * @param {VisemeConfig} config - 当前使用的映射配置。
+ * @returns {{ visemeId: number, mouth: number }} 口型编号及对应张嘴幅度。
+ */
+export const mapPhonemeToViseme = (phoneme, config) => {
+  const normalized = phoneme.trim();
+  const { phonemeToViseme, visemeToMouth } = config;
+  const visemeId = Object.prototype.hasOwnProperty.call(phonemeToViseme, normalized)
+    ? phonemeToViseme[normalized]
+    : phonemeToViseme.default;
+  const mouth = visemeToMouth[String(visemeId)] ?? visemeToMouth[visemeId] ?? 0.3;
+  return { visemeId: Number(visemeId), mouth };
+};
+
+/**
+ * 从 JSON 文件加载自定义口型映射。文件需包含 `phonemeToViseme` 与 `visemeToMouth` 两个字段。
+ * 若路径为空或解析失败，将返回 fallback 配置。
+ * @param {string|undefined} filePath - JSON 文件路径，可以是相对路径。
+ * @param {VisemeConfig} fallback - 默认配置。
+ * @returns {VisemeConfig} 合并后的配置。
+ */
+export const loadVisemeConfig = (filePath, fallback) => {
+  if (!filePath) {
+    return fallback;
+  }
+  try {
+    const absolute = path.resolve(process.cwd(), filePath);
+    const content = fs.readFileSync(absolute, 'utf-8');
+    const parsed = JSON.parse(content);
+    return {
+      phonemeToViseme: { ...fallback.phonemeToViseme, ...(parsed.phonemeToViseme || {}) },
+      visemeToMouth: { ...fallback.visemeToMouth, ...(parsed.visemeToMouth || {}) },
+      visemeMeta: { ...fallback.visemeMeta, ...(parsed.visemeMeta || {}) },
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console -- 配置解析失败时打印提醒即可
+    console.warn('[stickbot] 自定义口型映射解析失败，使用默认配置。', error);
+    return fallback;
+  }
+};
+

--- a/server/src/tts/providerFactory.js
+++ b/server/src/tts/providerFactory.js
@@ -1,0 +1,42 @@
+/**
+ * @file providerFactory.js
+ * @description 根据配置创建不同的 TTS 供应商实例，并提供统一的查找接口。
+ */
+
+import { EspeakAdapter } from './adapters/EspeakAdapter.js';
+import { AzureAdapter } from './adapters/AzureAdapter.js';
+
+/**
+ * @typedef {import('./ITtsProvider.js').ITtsProvider} ITtsProvider
+ * @typedef {import('../config.js').loadServerConfig} loadServerConfig
+ */
+
+/**
+ * 创建 provider 映射表。
+ * @param {Awaited<ReturnType<import('../config.js').loadServerConfig>>} config - 服务端配置。
+ * @returns {Record<string, ITtsProvider>} provider 实例集合。
+ */
+export const createProviders = (config) => {
+  const providers = {
+    espeak: new EspeakAdapter({
+      command: config.espeak.command,
+      voice: config.espeak.voice,
+      rate: config.espeak.rate,
+      tmpDir: config.tmpDir,
+      sampleRate: config.sampleRate,
+      visemeConfig: config.visemeConfig,
+    }),
+  };
+
+  if (config.azure.key && config.azure.region) {
+    providers.azure = new AzureAdapter({
+      region: config.azure.region,
+      key: config.azure.key,
+      tmpDir: config.tmpDir,
+      visemeConfig: config.visemeConfig,
+    });
+  }
+
+  return providers;
+};
+

--- a/server/src/tts/utils/timeline.js
+++ b/server/src/tts/utils/timeline.js
@@ -1,0 +1,85 @@
+/**
+ * @file timeline.js
+ * @description 提供音素时长到 mouth 时间轴的转换工具，包括积分、线性插值与稀疏化。
+ */
+
+/**
+ * @typedef {Object} PhonemeSegment
+ * @property {string} phoneme - 音素原始字符串。
+ * @property {number} durationMs - 持续时长（毫秒）。
+ * @property {number} visemeId - 映射后的口型编号。
+ * @property {number} mouth - 口型张合程度（0-1）。
+ */
+
+/**
+ * @typedef {Object} MouthKeyframe
+ * @property {number} t - 绝对时间（秒）。
+ * @property {number} v - mouth 值。
+ * @property {number} visemeId - 口型编号。
+ * @property {string} phoneme - 来源音素，便于调试。
+ */
+
+/**
+ * 根据音素片段生成累计时间轴。
+ * @param {PhonemeSegment[]} segments - 解析 `.pho` 后得到的音素片段。
+ * @returns {{ totalDuration: number, cumulative: Array<PhonemeSegment & { start: number, end: number }> }} 包含起止时间的片段数组。
+ */
+export const accumulateSegments = (segments) => {
+  const cumulative = [];
+  let cursor = 0;
+  for (const segment of segments) {
+    const start = cursor;
+    const end = cursor + segment.durationMs / 1000;
+    cumulative.push({ ...segment, start, end });
+    cursor = end;
+  }
+  return { totalDuration: cursor, cumulative };
+};
+
+/**
+ * 在固定采样率下生成 mouth 时间轴关键帧。
+ * @param {Array<PhonemeSegment & { start: number, end: number }>} cumulative - 带起止时间的音素片段。
+ * @param {number} totalDuration - 总时长（秒）。
+ * @param {number} sampleRate - 希望生成的时间轴频率（Hz），建议 60-100 之间。
+ * @returns {MouthKeyframe[]} mouth 关键帧数组。
+ */
+export const generateTimeline = (cumulative, totalDuration, sampleRate) => {
+  if (!Number.isFinite(totalDuration) || totalDuration <= 0) {
+    return [];
+  }
+  const frames = [];
+  const step = 1 / sampleRate;
+  const frameCount = Math.ceil(totalDuration / step);
+  let pointer = 0;
+  for (let i = 0; i <= frameCount; i += 1) {
+    const time = Math.min(i * step, totalDuration);
+    while (pointer < cumulative.length - 1 && time > cumulative[pointer].end) {
+      pointer += 1;
+    }
+    const segment = cumulative[pointer] || cumulative[cumulative.length - 1];
+    frames.push({
+      t: time,
+      v: segment.mouth,
+      visemeId: segment.visemeId,
+      phoneme: segment.phoneme,
+    });
+  }
+  return frames;
+};
+
+/**
+ * 针对临界场景（如 `.pho` 为短促爆破音导致时间轴为空）进行兜底处理。
+ * @param {MouthKeyframe[]} frames - 生成的 mouth 时间轴。
+ * @returns {MouthKeyframe[]} 若无帧则返回最小占位关键帧。
+ */
+export const ensureTimelineFallback = (frames) => {
+  if (frames.length > 0) {
+    return frames;
+  }
+  return [
+    { t: 0, v: 0.1, visemeId: 0, phoneme: 'sil' },
+    { t: 0.2, v: 0.4, visemeId: 2, phoneme: 'sil' },
+    { t: 0.4, v: 0.1, visemeId: 0, phoneme: 'sil' },
+  ];
+};
+

--- a/weapp-stickbot/README.md
+++ b/weapp-stickbot/README.md
@@ -1,0 +1,69 @@
+# stickbot 微信小程序骨架（第二轮）
+
+本目录提供可运行的小程序页面骨架，负责请求服务端 `/tts` 并播放返回的音频。核心目标：
+
+1. 使用 `innerAudioContext` 播放服务端生成的 WAV；
+2. 以 50~80ms 的间隔根据时间轴插值当前 mouth 值，驱动画布上的“大嘴巴头”；
+3. 支持 Vector 与 Sprite 两种渲染模式，便于自定义贴图。
+
+## 目录结构
+
+- `app.js` / `app.json` / `app.wxss`：全局配置。
+- `pages/index`：主页面，实现文本输入、TTS 调用与口型渲染。
+- `assets/`（可选）：用户可自行放置 `mouth/v0.png` 等贴图文件。
+
+## 使用步骤
+
+1. 在小程序管理后台添加合法域名（开发环境可勾选“开发阶段忽略”），确保包含 `http://localhost:8787` 或部署地址。
+2. `npm install` 并运行 `npm run dev:server`，确认服务端 `/tts` 正常返回 `audioUrl` 与 `mouthTimeline`。
+3. 使用微信开发者工具导入 `weapp-stickbot` 目录，真机或模拟器运行。
+4. 若服务端域名非默认 `http://localhost:8787`，可在 `pages/index/index.js` 的 `data.serverOrigin` 中设置为 HTTPS 正式地址。
+
+## 接口约定
+
+服务端 `/tts` 返回格式需包含：
+
+```json
+{
+  "audioUrl": "/audio/<uuid>.wav",
+  "mouthTimeline": [
+    { "t": 0, "v": 0.05, "visemeId": 0 },
+    { "t": 0.0125, "v": 0.32, "visemeId": 2 }
+  ],
+  "provider": "espeak",
+  "sampleRate": 80
+}
+```
+
+小程序会将 `audioUrl` 拼接到服务端域名，并使用 `mouthTimeline` 驱动口型；若数组为空，将回退到默认嘴型（嘴巴轻微开合）。
+
+## 时间轴消费策略
+
+- `interpolateTimeline` 会对时间轴进行线性插值：
+  - 若 `time` 落在 `[t_i, t_{i+1}]`，采用 `v_i + (v_{i+1}-v_i)*ratio` 计算当前 mouth；
+  - `visemeId` 采用距离更近的一个，避免频繁切换。
+- 定时器使用 `setInterval`，周期约 66ms（15FPS），可根据性能调节 `TIMER_INTERVAL`。
+- 播放结束或用户点击停止时会调用 `stopTimelineLoop()`，清理定时器并重置口型。
+
+## 渲染模式
+
+- **Vector 模式**：使用 Canvas 绘制火柴人身体与大嘴巴头：
+  - 上唇/下唇为贝塞尔曲线，牙齿由短矩形组成；
+  - `visemeId = 9`（圆唇类）会绘制额外椭圆高光；
+  - `mouth` 值控制嘴巴高度、头部轻微浮动。
+- **Sprite 模式**：
+  - 尝试加载 `spriteBasePath`（默认 `/assets/mouth`）下的 `v0.png ~ vN.png`；
+  - 若对应文件不存在，会回退到 Vector 模式并在控制台提示；
+  - 建议贴图尺寸一致且背景透明。
+
+## 性能建议
+
+- `innerAudioContext` 默认 `obeyMuteSwitch=false`，可根据需求调整。
+- 若时间轴较长，可将 `TIMER_INTERVAL` 调整为 50ms 提升跟随精度，或适当增大以降低耗电。
+- 在弱性能设备上，可将 Canvas 尺寸降低至 `240x320` 并减小线宽。
+
+## 域名配置
+
+- **开发阶段**：可在微信开发者工具的“详情 → 本地设置”勾选“忽略合法域名校验”，指向本地 `http://localhost:8787`。
+- **生产部署**：需在微信公众平台配置 HTTPS 域名，并在服务器启用 CORS 白名单，确保 `wx.request` 可以访问 `/tts` 与 `/audio`。
+

--- a/weapp-stickbot/app.js
+++ b/weapp-stickbot/app.js
@@ -1,0 +1,10 @@
+/**
+ * @file app.js
+ * @description stickbot 微信小程序入口，第二轮中主要初始化全局配置。
+ */
+App({
+  onLaunch() {
+    // 预留：可在此读取本地存储的服务端地址或初始化日志模块。
+    console.log('stickbot 小程序启动');
+  },
+});

--- a/weapp-stickbot/app.json
+++ b/weapp-stickbot/app.json
@@ -1,0 +1,10 @@
+{
+  "pages": [
+    "pages/index/index"
+  ],
+  "window": {
+    "navigationBarTitleText": "stickbot 大嘴巴头",
+    "navigationBarBackgroundColor": "#f3f4f6",
+    "backgroundColor": "#f3f4f6"
+  }
+}

--- a/weapp-stickbot/app.wxss
+++ b/weapp-stickbot/app.wxss
@@ -1,0 +1,4 @@
+page {
+  background: #f3f4f6;
+  color: #1f2937;
+}

--- a/weapp-stickbot/pages/index/index.js
+++ b/weapp-stickbot/pages/index/index.js
@@ -1,0 +1,437 @@
+/**
+ * @file index.js
+ * @description 微信小程序首页，调用服务端 TTS 并根据 mouth 时间轴驱动“大嘴巴头”。
+ */
+
+const DEFAULT_SERVER_ORIGIN = 'http://localhost:8787';
+const RENDER_MODES = ['Vector', 'Sprite'];
+const PROVIDER_LABELS = ['espeak', 'azure'];
+const TIMER_INTERVAL = 66; // 约 15 FPS，对应 60~80Hz 插值节奏
+
+/**
+ * 线性插值 mouth 时间轴。
+ * @param {{ t: number, v: number, visemeId: number }[]} timeline - mouth 时间轴。
+ * @param {number} time - 当前播放进度（秒）。
+ * @returns {{ value: number, visemeId: number }} mouth 帧。
+ */
+function interpolateTimeline(timeline, time) {
+  if (!timeline || timeline.length === 0) {
+    return { value: 0.1, visemeId: 0 };
+  }
+  if (time <= timeline[0].t) {
+    return { value: timeline[0].v, visemeId: timeline[0].visemeId };
+  }
+  for (let i = 1; i < timeline.length; i += 1) {
+    const prev = timeline[i - 1];
+    const next = timeline[i];
+    if (time <= next.t) {
+      const span = Math.max(next.t - prev.t, 1e-6);
+      const ratio = (time - prev.t) / span;
+      const value = prev.v + (next.v - prev.v) * ratio;
+      const visemeId = ratio > 0.5 ? next.visemeId : prev.visemeId;
+      return { value, visemeId };
+    }
+  }
+  const last = timeline[timeline.length - 1];
+  return { value: last.v, visemeId: last.visemeId };
+}
+
+Page({
+  data: {
+    text: '你好，我是 stickbot，大嘴巴头准备就绪！',
+    providers: PROVIDER_LABELS,
+    providerIndex: 0,
+    renderModes: RENDER_MODES,
+    renderModeIndex: 0,
+    mouth: 0.1,
+    mouthDisplay: '0.10',
+    visemeId: 0,
+    serverOrigin: '',
+    spriteBasePath: '/assets/mouth',
+  },
+  /**
+   * 生命周期函数：初始化画布、音频与服务端信息。
+   */
+  onLoad() {
+    this.canvasCtx = wx.createCanvasContext('avatar');
+    this.canvasWidth = 320;
+    this.canvasHeight = 420;
+    this.spriteCache = {};
+    this.pendingSprites = {};
+    this.timeline = [];
+    this.timelineTimer = null;
+    this.timelineStart = 0;
+
+    this.innerAudio = wx.createInnerAudioContext();
+    this.innerAudio.obeyMuteSwitch = false;
+    this.innerAudio.onPlay(() => {
+      this.startTimelineLoop();
+    });
+    this.innerAudio.onStop(() => {
+      this.stopTimelineLoop();
+    });
+    this.innerAudio.onEnded(() => {
+      this.stopTimelineLoop();
+      this.resetMouth();
+    });
+    this.innerAudio.onError((err) => {
+      console.error('播放失败', err);
+      this.stopTimelineLoop();
+      this.resetMouth();
+    });
+
+    this.drawAvatar();
+    this.fetchProviders();
+  },
+  /**
+   * 页面卸载时清理资源。
+   */
+  onUnload() {
+    this.stopPlayback();
+    if (this.innerAudio) {
+      this.innerAudio.destroy();
+    }
+  },
+  /**
+   * 文本输入事件。
+   * @param {WechatMiniprogram.TextareaInput} event - 输入事件对象。
+   */
+  onTextInput(event) {
+    this.setData({ text: event.detail.value });
+  },
+  /**
+   * 切换 TTS 供应器。
+   * @param {WechatMiniprogram.PickerChange} event - 选择事件。
+   */
+  onProviderChange(event) {
+    this.setData({ providerIndex: Number(event.detail.value) });
+  },
+  /**
+   * 切换渲染模式。
+   * @param {WechatMiniprogram.PickerChange} event - 选择事件。
+   */
+  onRenderModeChange(event) {
+    this.setData({ renderModeIndex: Number(event.detail.value) });
+    this.drawAvatar();
+  },
+  /**
+   * 点击“开始合成”。
+   */
+  onSynthesize() {
+    const text = this.data.text.trim();
+    if (!text) {
+      wx.showToast({ title: '请输入文本', icon: 'none' });
+      return;
+    }
+    this.stopPlayback();
+    wx.showLoading({ title: '合成中...' });
+    this.requestTts(text)
+      .then((result) => {
+        if (!result.audioUrl) {
+          wx.showToast({ title: '未返回音频', icon: 'none' });
+          return;
+        }
+        this.timeline = result.mouthTimeline || [];
+        this.innerAudio.src = this.resolveServerUrl(result.audioUrl);
+        this.innerAudio.play();
+      })
+      .catch((error) => {
+        console.error('请求 TTS 失败', error);
+        wx.showToast({ title: 'TTS 请求失败', icon: 'none' });
+      })
+      .finally(() => {
+        wx.hideLoading();
+      });
+  },
+  /**
+   * 点击“停止”。
+   */
+  onStop() {
+    this.stopPlayback();
+  },
+  /**
+   * 停止音频与时间轴。
+   */
+  stopPlayback() {
+    this.stopTimelineLoop();
+    if (this.innerAudio && !this.innerAudio.paused) {
+      this.innerAudio.stop();
+    }
+    this.resetMouth();
+  },
+  /**
+   * 重置 mouth 状态并重绘。
+   */
+  resetMouth() {
+    this.setData({ mouth: 0.1, mouthDisplay: '0.10', visemeId: 0 });
+    this.drawAvatar();
+  },
+  /**
+   * 调用服务端 `/tts`。
+   * @param {string} text - 待合成文本。
+   * @returns {Promise<{ audioUrl: string, mouthTimeline: { t: number, v: number, visemeId: number }[] }>} 结果。
+   */
+  requestTts(text) {
+    const provider = this.data.providers[this.data.providerIndex];
+    const origin = this.getServerOrigin();
+    return new Promise((resolve, reject) => {
+      wx.request({
+        url: `${origin}/tts`,
+        method: 'GET',
+        data: {
+          text,
+          provider,
+        },
+        success: (res) => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(res.data);
+          } else {
+            reject(new Error(`HTTP ${res.statusCode}`));
+          }
+        },
+        fail: reject,
+      });
+    });
+  },
+  /**
+   * 获取服务端地址，可在 data.serverOrigin 中覆盖。
+   * @returns {string} 服务端基础 URL。
+   */
+  getServerOrigin() {
+    return this.data.serverOrigin || DEFAULT_SERVER_ORIGIN;
+  },
+  /**
+   * 将相对路径转换为绝对 URL。
+   * @param {string} path - 相对路径。
+   * @returns {string} 完整 URL。
+   */
+  resolveServerUrl(path) {
+    if (!path) return this.getServerOrigin();
+    if (/^https?:/i.test(path)) {
+      return path;
+    }
+    return `${this.getServerOrigin()}${path}`;
+  },
+  /**
+   * 启动时间轴定时器，每 50~80ms 更新一次口型。
+   */
+  startTimelineLoop() {
+    this.stopTimelineLoop();
+    if (!this.timeline || this.timeline.length === 0) {
+      return;
+    }
+    this.timelineStart = Date.now();
+    this.timelineTimer = setInterval(() => {
+      const elapsed = (Date.now() - this.timelineStart) / 1000;
+      const frame = interpolateTimeline(this.timeline, elapsed);
+      this.updateMouthFrame(frame.value, frame.visemeId);
+      const lastTime = this.timeline[this.timeline.length - 1]?.t || 0;
+      if (elapsed >= lastTime) {
+        this.stopTimelineLoop();
+      }
+    }, TIMER_INTERVAL);
+  },
+  /**
+   * 停止时间轴定时器。
+   */
+  stopTimelineLoop() {
+    if (this.timelineTimer) {
+      clearInterval(this.timelineTimer);
+      this.timelineTimer = null;
+    }
+  },
+  /**
+   * 更新 mouth 并重绘。
+   * @param {number} value - mouth 值。
+   * @param {number} visemeId - 口型编号。
+   */
+  updateMouthFrame(value, visemeId) {
+    const clamped = Math.max(0, Math.min(1, value));
+    this.setData({
+      mouth: clamped,
+      mouthDisplay: clamped.toFixed(2),
+      visemeId,
+    });
+    this.drawAvatar();
+  },
+  /**
+   * 绘制火柴人 + 大嘴巴头。
+   */
+  drawAvatar() {
+    const ctx = this.canvasCtx;
+    if (!ctx) return;
+    const mouth = this.data.mouth;
+    const visemeId = this.data.visemeId;
+    ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+    ctx.save();
+    ctx.translate(this.canvasWidth / 2, this.canvasHeight / 2 + 40);
+    ctx.setLineCap('round');
+    this.drawBody(ctx);
+    if (this.data.renderModes[this.data.renderModeIndex] === 'Sprite') {
+      this.drawSpriteHead(ctx, mouth, visemeId);
+    } else {
+      this.drawVectorHead(ctx, mouth, visemeId);
+    }
+    ctx.restore();
+    ctx.draw();
+  },
+  /**
+   * 绘制身体。
+   * @param {WechatMiniprogram.CanvasContext} ctx - 画布上下文。
+   */
+  drawBody(ctx) {
+    const time = Date.now() / 1000;
+    const swing = Math.sin(time * 1.5) * 0.22;
+    const jitter = (Math.random() - 0.5) * 0.05 * (0.2 + this.data.mouth);
+    ctx.setStrokeStyle('#1f2937');
+    ctx.setLineWidth(6);
+
+    ctx.beginPath();
+    ctx.moveTo(0, -120);
+    ctx.lineTo(0, 40);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(0, -80);
+    ctx.lineTo(-70, -80 + Math.sin(time * 1.5 + Math.PI / 4) * 32);
+    ctx.moveTo(0, -80);
+    ctx.lineTo(70, -80 + Math.sin(time * 1.5 + Math.PI + jitter) * 32);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(0, 40);
+    ctx.lineTo(-50, 140 + swing * 40);
+    ctx.moveTo(0, 40);
+    ctx.lineTo(50, 140 - swing * 40);
+    ctx.stroke();
+  },
+  /**
+   * 绘制矢量大嘴巴头。
+   * @param {WechatMiniprogram.CanvasContext} ctx - 画布上下文。
+   * @param {number} mouth - mouth 值。
+   * @param {number} visemeId - 口型编号。
+   */
+  drawVectorHead(ctx, mouth, visemeId) {
+    const headY = -150 - mouth * 8;
+    const headRadius = 48;
+    const mouthWidthBase = 70;
+    const mouthHeight = 8 + mouth * 48;
+    const rounded = Math.round(visemeId) === 9;
+    const widthFactor = rounded ? 0.65 : 1;
+
+    ctx.setLineWidth(5);
+    ctx.setStrokeStyle('#111827');
+    ctx.setFillStyle('#f9fafb');
+    ctx.beginPath();
+    ctx.arc(0, headY, headRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    const eyeGap = 20;
+    const eyeHeight = Math.max(2, 10 * (1 - Math.min(1, mouth * 1.4)));
+    ctx.setLineWidth(4);
+    ctx.beginPath();
+    ctx.moveTo(-eyeGap, headY - 12);
+    ctx.lineTo(-eyeGap, headY - 12 + eyeHeight);
+    ctx.moveTo(eyeGap, headY - 12);
+    ctx.lineTo(eyeGap, headY - 12 + eyeHeight);
+    ctx.stroke();
+
+    const mouthWidth = mouthWidthBase * widthFactor;
+    const lipTopY = headY + 18;
+    const lipBottomY = lipTopY + mouthHeight;
+    const controlOffset = mouthHeight * 0.7;
+
+    ctx.setLineWidth(6);
+    ctx.setStrokeStyle('#ef4444');
+    ctx.beginPath();
+    ctx.moveTo(-mouthWidth, lipTopY);
+    ctx.bezierCurveTo(-mouthWidth * 0.4, lipTopY - controlOffset, mouthWidth * 0.4, lipTopY - controlOffset, mouthWidth, lipTopY);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(-mouthWidth, lipBottomY);
+    ctx.bezierCurveTo(-mouthWidth * 0.4, lipBottomY + controlOffset, mouthWidth * 0.4, lipBottomY + controlOffset, mouthWidth, lipBottomY);
+    ctx.stroke();
+
+    ctx.setFillStyle('#7f1d1d');
+    ctx.beginPath();
+    ctx.moveTo(-mouthWidth + 3, lipTopY + 3);
+    ctx.bezierCurveTo(-mouthWidth * 0.3, lipTopY + 3 - controlOffset * 0.8, mouthWidth * 0.3, lipTopY + 3 - controlOffset * 0.8, mouthWidth - 3, lipTopY + 3);
+    ctx.lineTo(mouthWidth - 3, lipBottomY - 3);
+    ctx.bezierCurveTo(mouthWidth * 0.3, lipBottomY - 3 + controlOffset * 0.8, -mouthWidth * 0.3, lipBottomY - 3 + controlOffset * 0.8, -mouthWidth + 3, lipBottomY - 3);
+    ctx.closePath();
+    ctx.fill();
+
+    if (mouthHeight > 12) {
+      ctx.setFillStyle('#fefce8');
+      const toothCount = Math.min(6, Math.max(3, Math.floor(mouthWidth / 14)));
+      const toothWidth = (mouthWidth * 1.8) / toothCount / 2;
+      const toothHeight = Math.min(12, mouthHeight * 0.4);
+      for (let i = 0; i < toothCount; i += 1) {
+        const ratio = (i / (toothCount - 1)) * 2 - 1;
+        const x = ratio * mouthWidth * 0.7;
+        ctx.fillRect(x - toothWidth / 2, lipTopY + 2, toothWidth, toothHeight);
+      }
+    }
+
+    if (rounded) {
+      ctx.setStrokeStyle('#fca5a5');
+      ctx.setLineWidth(2);
+      ctx.beginPath();
+      ctx.ellipse(0, (lipTopY + lipBottomY) / 2, mouthWidth * 0.7, mouthHeight * 0.4, 0, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  },
+  /**
+   * 绘制 Sprite 头部，如无资源则回退至矢量模式。
+   * @param {WechatMiniprogram.CanvasContext} ctx - 画布上下文。
+   * @param {number} mouth - mouth 值。
+   * @param {number} visemeId - 口型编号。
+   */
+  drawSpriteHead(ctx, mouth, visemeId) {
+    const key = Math.round(visemeId);
+    const cached = this.spriteCache[key];
+    if (cached) {
+      const headY = -180;
+      const scale = 1 + mouth * 0.1;
+      const width = cached.width * scale;
+      const height = cached.height * scale;
+      ctx.drawImage(cached.path, -width / 2, headY - height / 2, width, height);
+      return;
+    }
+    if (!this.pendingSprites[key]) {
+      this.pendingSprites[key] = true;
+      const src = `${this.data.spriteBasePath}/v${key}.png`;
+      wx.getImageInfo({
+        src,
+        success: (res) => {
+          this.spriteCache[key] = { path: res.path, width: res.width, height: res.height };
+          this.drawAvatar();
+        },
+        fail: () => {
+          console.warn('未找到 Sprite 资源：', src);
+        },
+        complete: () => {
+          this.pendingSprites[key] = false;
+        },
+      });
+    }
+    this.drawVectorHead(ctx, mouth, visemeId);
+  },
+  /**
+   * 拉取服务端可用 provider。
+   */
+  fetchProviders() {
+    const origin = this.getServerOrigin();
+    wx.request({
+      url: `${origin}/`,
+      success: (res) => {
+        const list = Array.isArray(res.data?.providers) ? res.data.providers : PROVIDER_LABELS;
+        this.setData({ providers: list, providerIndex: 0 });
+      },
+      fail: () => {
+        console.warn('获取 provider 列表失败');
+      },
+    });
+  },
+});

--- a/weapp-stickbot/pages/index/index.json
+++ b/weapp-stickbot/pages/index/index.json
@@ -1,0 +1,3 @@
+{
+  "usingComponents": {}
+}

--- a/weapp-stickbot/pages/index/index.wxml
+++ b/weapp-stickbot/pages/index/index.wxml
@@ -1,0 +1,24 @@
+<view class="container">
+  <canvas type="2d" canvas-id="avatar" style="width: 320px; height: 420px; background: #ffffff; border-radius: 16px;"></canvas>
+  <view class="panel">
+    <textarea class="text-input" value="{{text}}" placeholder="请输入要朗读的文本" bindinput="onTextInput"></textarea>
+    <view class="selector">
+      <text class="label">TTS 供应器</text>
+      <picker mode="selector" range="{{providers}}" value="{{providerIndex}}" bindchange="onProviderChange">
+        <view class="picker-value">{{providers[providerIndex]}}</view>
+      </picker>
+    </view>
+    <view class="selector">
+      <text class="label">渲染模式</text>
+      <picker mode="selector" range="{{renderModes}}" value="{{renderModeIndex}}" bindchange="onRenderModeChange">
+        <view class="picker-value">{{renderModes[renderModeIndex]}}</view>
+      </picker>
+    </view>
+    <view class="info">当前 mouth：{{mouthDisplay}}，viseme：{{visemeId}}</view>
+    <view class="button-group">
+      <button type="primary" bindtap="onSynthesize">开始合成</button>
+      <button type="default" bindtap="onStop">停止</button>
+    </view>
+    <view class="hint">服务端需在可信域名下运行，Sprite 贴图放入 <text selectable="true">/assets/mouth/v0.png</text> 等文件。</view>
+  </view>
+</view>

--- a/weapp-stickbot/pages/index/index.wxss
+++ b/weapp-stickbot/pages/index/index.wxss
@@ -1,0 +1,60 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px;
+  gap: 16px;
+}
+
+.panel {
+  width: 320px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.text-input {
+  width: 100%;
+  min-height: 100px;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 14px;
+}
+
+.selector {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label {
+  font-size: 14px;
+  color: #4b5563;
+}
+
+.picker-value {
+  padding: 10px 12px;
+  background: #f3f4f6;
+  border-radius: 10px;
+  color: #1f2937;
+}
+
+.info {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.button-group {
+  display: flex;
+  gap: 12px;
+}
+
+.hint {
+  font-size: 12px;
+  color: #9ca3af;
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,31 +1,60 @@
-# Web 前端模块说明
+# Web 前端模块说明（第二轮）
 
-该目录包含 stickbot 的纯静态网页演示，实现要点如下：
+网页端展示了“大嘴巴火柴人”动画，并根据服务端返回的 mouth 时间轴驱动唇形。项目仍为纯静态资源，可通过任意静态服务器托管。
 
-- **`index.html`**：构建左画布右控制面板的布局，引入 `main.js` 作为入口。
-- **`js/avatar.js`**：封装画布绘制逻辑，负责火柴人骨架、眨眼、肢体摆动与口型渲染。
-- **`js/lipsync.js`**：提供口型信号控制器，兼容 Web Speech 边界事件、Web Audio 能量包络与时间轴驱动。
-- **`js/main.js`**：处理 UI 事件、拼装口型策略并与服务端占位接口通讯。
+## 目录结构
 
-## 口型驱动原理
+- **`index.html`**：页面骨架与样式，包含渲染模式、TTS 供应器选择等控件。
+- **`js/main.js`**：入口脚本，负责：
+  - 根据用户输入调用服务端 `/tts`，优先消费 `mouthTimeline`；
+  - 管理 Web Speech / 音量包络回退，并处理停止逻辑；
+  - 与 `BigMouthAvatar`、`MouthSignal` 协同更新 UI。
+- **`js/avatar.js`**：实现 `BigMouthAvatar`，绘制火柴人身体 + 大嘴巴头，支持 Vector / Sprite 两种模式。
+- **`js/lipsync.js`**：封装口型信号、时间轴插值与服务端请求，提供 `resolveServerUrl` 以跨源访问。
 
-1. **Web Speech 优先**：浏览器支持 `SpeechSynthesisUtterance` 时，使用 `onboundary` 事件触发 `MouthSignal.pulse`，结合指数衰减实现自然开合。
-2. **音量包络回退**：若 Web Speech 不可用，则 `fetchTtsFallback` 请求 `/tts`。当返回音频时，通过 Web Audio `AnalyserNode` 计算 RMS 能量，映射到 0~1 的 mouth 值。
-3. **占位时间轴**：当前服务端仅返回文本提示时，`generatePlaceholderTimeline` 会基于字符数构造一个合成的 mouth 时间轴，让火柴人仍保持动态。
+## 口型驱动优先级
 
-## 可调参数
+1. **服务端时间轴**：`/tts` 返回 `mouthTimeline` 时，`main.js` 会创建 `<audio>` 元素播放 `audioUrl`，同时调用 `MouthSignal.playTimeline`，以 ~80Hz 的关键帧驱动嘴唇开合。
+2. **Web Speech 边界事件**：若时间轴缺失且浏览器支持 `SpeechSynthesisUtterance`，则监听 `boundary` 事件触发脉冲，并衰减 mouth 值。
+3. **音量包络分析**：服务端仅返回音频时，通过 Web Audio `AnalyserNode` 计算 RMS 映射到 mouth，保持基本的张合效果。
+4. **占位时间轴**：以上途径均不可用时，会使用 `generatePlaceholderTimeline` 生成简易口型曲线，避免角色僵硬。
 
-| 模块 | 常量 | 建议范围 | 说明 |
-| --- | --- | --- | --- |
-| `avatar.js` | `blinkIntervalRange` | `[2, 5]` 秒 | 控制眨眼频率，范围越大越自然。 |
-| `avatar.js` | `limbSwingAmplitude` | `0.1 ~ 0.4` | 肢体摆动幅度，配合语速可做轻微抖动。 |
-| `avatar.js` | `mouthSmoothing` | `0.1 ~ 0.3` | 口型平滑系数，增大可减缓跳变。 |
-| `lipsync.js` | `SIGNAL_CONFIG.decay` | `0.85 ~ 0.95` | 衰减速度，越小闭口越快。 |
-| `main.js` | 语速滑条范围 | `0.5 ~ 2` | 直接映射到 Web Speech `rate`。 |
+## 大嘴巴头像
 
-## 开发调试建议
+- Vector 模式完全依赖 Canvas 绘制：
+  - 上下唇由贝塞尔曲线构成，mouth 值越大，高度越高；
+  - 牙齿使用多段短矩形表示，并随开口度调整数量与高度；
+  - 口型 `visemeId = 9` 时额外绘制高光，模拟圆唇收紧效果。
+- Sprite 模式按 `visemeId` 选择贴图：
+  - 用户可在 `web/assets/mouth/` 目录放入 `v0.png` ~ `vN.png`（不在仓库提交）；
+  - 切换到 Sprite 模式时会按编号加载图片，若资源缺失会自动回退到 Vector 模式；
+  - 可通过 `avatar.configureSprite({ basePath, maxViseme })` 自定义路径与数量。
 
-1. 运行 `npm run dev:web` 启动静态服务器，浏览器打开 `http://localhost:5173`。
-2. 在控制台关注 `[stickbot]` 前缀日志，以了解当前策略与错误信息。
-3. 可在 `avatar.js` 中引入更多肢体状态（如抬手、点头），只需根据 mouth 值或时间驱动即可。
-4. 准备接入真实 `mouthTimeline` 时，只需在 `main.js` 获取后调用 `mouthSignal.playEnvelope(timeline, performance.now())`，即可替换现有脉冲与包络策略。
+## TTS 供应器与跨域
+
+- `main.js` 会自动探测服务端 `/` 返回的 `providers` 列表，未启用的项（如 Azure）会禁用选项。
+- `lipsync.js` 的 `resolveServerUrl` 默认指向 `http://<当前主机>:8787`，可在浏览器全局注入 `window.STICKBOT_SERVER_ORIGIN` 覆盖。
+- 开发环境推荐同时运行 `npm run dev:web` 与 `npm run dev:server`，确保前端可以跨域访问。
+
+## Sprite 资源投放
+
+```
+web/
+  assets/
+    mouth/
+      v0.png  # 闭口
+      v1.png  # 半开
+      ...
+```
+
+- 文件名中的数字应与口型 `visemeId` 一致（0~9 为默认映射）。
+- 图片建议采用透明背景、相同分辨率，避免切换时抖动。
+- 若只准备部分口型，缺失编号会自动回落到向量绘制。
+
+## 调试建议
+
+1. 运行 `npm run dev:web`，浏览器打开 `http://localhost:5173`。
+2. 在控制面板查看 `TTS 供应器` 选项，确认服务端返回的 `mouthTimeline` 是否生效（控制台会输出 `[stickbot] 使用服务端时间轴驱动口型。`）。
+3. 切换渲染模式观察差异，若 Sprite 未加载成功，会有提示信息。
+4. 开发自定义口型映射时，可在控制台打印 `viseme` 与 `phoneme`（`main.js` 已在进度条旁显示）。
+

--- a/web/index.html
+++ b/web/index.html
@@ -86,6 +86,12 @@
         gap: 4px;
       }
 
+      .selector-group {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
       .progress-container {
         display: flex;
         flex-direction: column;
@@ -112,9 +118,24 @@
       <section class="controls">
         <h1 style="margin: 0">stickbot 控制面板</h1>
         <textarea id="speech-text" placeholder="请输入要朗读的文本">你好，我是 stickbot。今天我们一起练习口型同步！</textarea>
+        <div class="selector-group">
+          <label for="tts-provider">TTS 供应器</label>
+          <select id="tts-provider">
+            <option value="espeak">eSpeak NG（本地命令行）</option>
+            <option value="azure">Azure（需手动配置）</option>
+          </select>
+          <small id="provider-hint" style="color: #6b7280">服务端会优先尝试返回 mouth 时间轴。</small>
+        </div>
+        <div class="selector-group">
+          <label for="render-mode">渲染模式</label>
+          <select id="render-mode">
+            <option value="vector">Vector（默认）</option>
+            <option value="sprite">Sprite（需手动放置贴图）</option>
+          </select>
+        </div>
         <label>
           <input type="checkbox" id="use-webspeech" checked />
-          使用浏览器 Web Speech API
+          无时间轴时尝试使用浏览器 Web Speech API
         </label>
         <div class="slider-group">
           <span>语速：<span id="rate-display">1.0</span></span>
@@ -125,7 +146,7 @@
           <input type="range" id="pitch-slider" min="0" max="2" step="0.1" value="1" />
         </div>
         <div class="progress-container">
-          <span>口型幅度</span>
+          <span>口型幅度 <span id="viseme-display" style="font-size: 12px; color: #6b7280"></span></span>
           <progress id="mouth-progress" value="0" max="1"></progress>
         </div>
         <div style="display: flex; gap: 12px">
@@ -133,7 +154,8 @@
           <button class="secondary" id="stop-btn">停止</button>
         </div>
         <p style="font-size: 13px; color: #4b5563; margin: 0">
-          提示：若浏览器不支持 Web Speech，取消勾选后将调用服务端 `/tts` 占位接口，并使用音量包络回退策略。
+          优先级：服务端时间轴 &gt; Web Speech 边界事件 &gt; 音量包络回退。Sprite 模式需要在 <code>web/assets/mouth</code>
+          目录放入 v0.png~vN.png。
         </p>
       </section>
     </main>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,17 +1,20 @@
 /**
  * @module main
- * @description 浏览器入口脚本，负责页面交互、口型驱动策略选择以及与 avatar.js 的集成。
- * 设计原则：
- * 1. 将渲染与口型逻辑解耦，main.js 只处理 DOM 和策略切换；
- * 2. 对 Web Speech 与回退策略进行能力检测，确保在任何浏览器都不会抛错；
- * 3. 通过 AbortController 管理异步流程，避免重复点击造成状态紊乱。
+ * @description 浏览器入口逻辑：协调 UI、TTS 请求与 BigMouthAvatar 渲染。
  */
 
-import { StickbotAvatar } from './avatar.js';
-import { MouthSignal, speakWithWebSpeech, fetchTtsFallback, generatePlaceholderTimeline } from './lipsync.js';
+import { BigMouthAvatar } from './avatar.js';
+import {
+  MouthSignal,
+  speakWithWebSpeech,
+  generatePlaceholderTimeline,
+  requestServerTts,
+  playWithAnalyser,
+  resolveServerUrl,
+} from './lipsync.js';
 
 /**
- * 页面初始化：查找 DOM 元素并建立引用。
+ * DOM 引用。
  */
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById('stickbot-canvas'));
 const textArea = /** @type {HTMLTextAreaElement} */ (document.getElementById('speech-text'));
@@ -23,38 +26,64 @@ const pitchSlider = /** @type {HTMLInputElement} */ (document.getElementById('pi
 const rateDisplay = document.getElementById('rate-display');
 const pitchDisplay = document.getElementById('pitch-display');
 const mouthProgress = /** @type {HTMLProgressElement} */ (document.getElementById('mouth-progress'));
+const providerSelect = /** @type {HTMLSelectElement} */ (document.getElementById('tts-provider'));
+const providerHint = document.getElementById('provider-hint');
+const renderSelect = /** @type {HTMLSelectElement} */ (document.getElementById('render-mode'));
+const visemeDisplay = document.getElementById('viseme-display');
 
-// 初始化火柴人并启动动画循环
-overlayInfo('初始化 stickbot...');
-const avatar = new StickbotAvatar(canvas);
+// 初始化渲染器
+const avatar = new BigMouthAvatar(canvas);
 avatar.start();
+overlayInfo('stickbot 已就绪，优先使用服务端时间轴驱动。');
 
-// MouthSignal 作为口型事件总线
+// 口型信号
 const mouthSignal = new MouthSignal();
-mouthSignal.subscribe((value) => {
-  avatar.setMouthValue(value);
-  mouthProgress.value = value;
+mouthSignal.subscribe((frame) => {
+  avatar.setMouthFrame(frame);
+  mouthProgress.value = frame.value;
+  if (visemeDisplay) {
+    visemeDisplay.textContent = `viseme ${Math.round(frame.visemeId)} · ${frame.phoneme}`;
+  }
 });
 
 /** @type {AbortController|null} */
 let currentAbort = null;
+/** @type {HTMLAudioElement|null} */
+let currentAudio = null;
+/** @type {number|null} */
+let placeholderTimer = null;
+/** @type {(() => void)|null} */
+let currentAudioCleanup = null;
 
 /**
- * 工具函数：更新进度文案。
- * @param {string} message - 要显示的提示。
+ * 输出调试信息。
+ * @param {string} message - 文案。
  */
 function overlayInfo(message) {
-  // 以 console 为主，避免干扰 UI；未来可扩展为 toast
   console.info(`[stickbot] ${message}`);
+  if (providerHint) {
+    providerHint.textContent = message;
+  }
 }
 
 /**
- * 工具函数：停止当前流程。
+ * 停止当前流程。
  */
 function stopCurrentPlayback() {
   if (currentAbort) {
     currentAbort.abort();
     currentAbort = null;
+  }
+  if (placeholderTimer) {
+    clearTimeout(placeholderTimer);
+    placeholderTimer = null;
+  }
+  if (currentAudio) {
+    currentAudio.pause();
+  }
+  if (currentAudioCleanup) {
+    currentAudioCleanup();
+    currentAudioCleanup = null;
   }
   if ('speechSynthesis' in window) {
     window.speechSynthesis.cancel();
@@ -63,7 +92,7 @@ function stopCurrentPlayback() {
   overlayInfo('已停止当前播放。');
 }
 
-// 绑定滑条显示
+// 滑条即时更新数值显示
 rateSlider.addEventListener('input', () => {
   rateDisplay.textContent = rateSlider.value;
 });
@@ -71,34 +100,92 @@ pitchSlider.addEventListener('input', () => {
   pitchDisplay.textContent = pitchSlider.value;
 });
 
-// 播放按钮逻辑
+// 渲染模式切换
+renderSelect.addEventListener('change', async () => {
+  const mode = renderSelect.value;
+  const ok = await avatar.setRenderMode(mode);
+  if (!ok) {
+    overlayInfo('未检测到 Sprite 资源，已回退至 Vector 模式。');
+    renderSelect.value = 'vector';
+  } else {
+    overlayInfo(`已切换至 ${mode} 渲染模式。`);
+  }
+});
+
+/**
+ * 播放按钮点击逻辑。
+ */
 playButton.addEventListener('click', async () => {
   const text = textArea.value.trim();
   if (!text) {
-    overlayInfo('请输入要朗读的文本。');
+    overlayInfo('请输入要朗读的文本，已播放占位口型。');
     const timeline = generatePlaceholderTimeline('...');
+    const startTime = performance.now();
     mouthSignal.start();
-    mouthSignal.playEnvelope(timeline, performance.now());
+    mouthSignal.playTimeline(timeline, () => (performance.now() - startTime) / 1000);
+    const duration = timeline.length > 0 ? timeline[timeline.length - 1].t : 1;
+    if (placeholderTimer) {
+      clearTimeout(placeholderTimer);
+    }
+    placeholderTimer = window.setTimeout(() => {
+      placeholderTimer = null;
+      mouthSignal.stop();
+    }, (duration + 0.4) * 1000);
     return;
   }
 
   stopCurrentPlayback();
   playButton.disabled = true;
-  overlayInfo('开始演示口型同步。');
+  overlayInfo('开始请求 TTS...');
 
   try {
-    if (useWebSpeechCheckbox.checked && 'speechSynthesis' in window) {
+    const provider = providerSelect.value;
+    const speechRate = parseFloat(rateSlider.value);
+    const espeakRate = Math.max(80, Math.round(170 * speechRate));
+    currentAbort = new AbortController();
+
+    let serverResult = null;
+    try {
+      serverResult = await requestServerTts(text, {
+        provider,
+        rate: espeakRate,
+        abortSignal: currentAbort.signal,
+      });
+    } catch (error) {
+      console.warn('调用服务端 TTS 失败，将尝试 Web Speech 或回退。', error);
+    }
+
+    if (serverResult && Array.isArray(serverResult.mouthTimeline) && serverResult.mouthTimeline.length > 0 && serverResult.audioUrl) {
+      overlayInfo('使用服务端时间轴驱动口型。');
+      await playWithTimeline(serverResult);
+    } else if (serverResult && serverResult.audioUrl) {
+      overlayInfo('服务端未提供时间轴，改用音量包络分析。');
+      await playWithAnalyserUrl(serverResult.audioUrl);
+    } else if (useWebSpeechCheckbox.checked && 'speechSynthesis' in window) {
+      overlayInfo('使用 Web Speech API 作为兜底。');
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = /[a-zA-Z]/.test(text) ? 'en-US' : 'zh-CN';
-      utterance.rate = parseFloat(rateSlider.value);
+      utterance.rate = speechRate;
       utterance.pitch = parseFloat(pitchSlider.value);
       await speakWithWebSpeech(utterance, mouthSignal);
     } else {
-      currentAbort = new AbortController();
-      await fetchTtsFallback(text, mouthSignal, currentAbort.signal);
+      overlayInfo('无法使用服务端或 Web Speech，播放占位时间轴。');
+      const placeholder = generatePlaceholderTimeline(text);
+      const startTime = performance.now();
+      mouthSignal.start();
+      mouthSignal.playTimeline(placeholder, () => (performance.now() - startTime) / 1000);
+      const duration = placeholder.length > 0 ? placeholder[placeholder.length - 1].t : 1;
+      if (placeholderTimer) {
+        clearTimeout(placeholderTimer);
+      }
+      placeholderTimer = window.setTimeout(() => {
+        placeholderTimer = null;
+        mouthSignal.stop();
+      }, (duration + 0.4) * 1000);
     }
   } catch (error) {
     console.error('播放失败：', error);
+    overlayInfo(`播放失败：${error instanceof Error ? error.message : String(error)}`);
     mouthSignal.stop();
   } finally {
     playButton.disabled = false;
@@ -107,21 +194,112 @@ playButton.addEventListener('click', async () => {
   }
 });
 
-// 停止按钮逻辑
+// 停止按钮
 stopButton.addEventListener('click', () => {
   stopCurrentPlayback();
 });
 
-// 在页面失焦时也停止播放，避免后台语音造成困扰
+// 页面隐藏时自动停止，避免后台播放
 document.addEventListener('visibilitychange', () => {
   if (document.hidden) {
     stopCurrentPlayback();
   }
 });
 
-// 为不支持 Web Speech 的浏览器展示一次提示
+// 不支持 Web Speech 时禁用选项
 if (!('speechSynthesis' in window)) {
   useWebSpeechCheckbox.checked = false;
   useWebSpeechCheckbox.disabled = true;
-  overlayInfo('当前浏览器不支持 Web Speech API，已自动切换为回退策略。');
+  overlayInfo('当前浏览器不支持 Web Speech API，已禁用相关选项。');
 }
+
+/**
+ * 使用时间轴播放音频。
+ * @param {{ audioUrl: string, mouthTimeline: import('./lipsync.js').TimelinePoint[], duration: number }} result - 服务端返回。
+ */
+async function playWithTimeline(result) {
+  return new Promise((resolve, reject) => {
+    const audio = new Audio(resolveServerUrl(result.audioUrl));
+    currentAudio = audio;
+    audio.crossOrigin = 'anonymous';
+
+    let settled = false;
+
+    const finalize = (status, error) => {
+      if (settled) return;
+      settled = true;
+      audio.removeEventListener('play', handlePlay);
+      audio.removeEventListener('ended', handleEnded);
+      audio.removeEventListener('error', handleError);
+      currentAudio = null;
+      currentAudioCleanup = null;
+      mouthSignal.stop();
+      if (status === 'error') {
+        reject(error || new Error('音频播放失败'));
+      } else {
+        resolve();
+      }
+    };
+
+    const handlePlay = () => {
+      mouthSignal.start();
+      mouthSignal.playTimeline(result.mouthTimeline, () => audio.currentTime);
+    };
+
+    const handleEnded = () => {
+      finalize('ended');
+    };
+
+    const handleError = (event) => {
+      finalize('error', event.error);
+    };
+
+    audio.addEventListener('play', handlePlay, { once: true });
+    audio.addEventListener('ended', handleEnded, { once: true });
+    audio.addEventListener('error', handleError, { once: true });
+
+    currentAudioCleanup = () => {
+      finalize('manual');
+    };
+
+    audio.play().catch((error) => {
+      finalize('error', error);
+    });
+  });
+}
+
+/**
+ * 通过音量包络播放音频。
+ * @param {string} url - 音频地址。
+ */
+async function playWithAnalyserUrl(url) {
+  if (!url) return;
+  const response = await fetch(resolveServerUrl(url), { signal: currentAbort?.signal });
+  await playWithAnalyser(response, mouthSignal);
+}
+
+/**
+ * 查询服务端可用 provider，更新下拉框禁用状态。
+ */
+async function initProviderAvailability() {
+  try {
+    const response = await fetch(resolveServerUrl('/'));
+    const data = await response.json();
+    const available = Array.isArray(data.providers) ? data.providers : [];
+    const azureOption = providerSelect.querySelector('option[value="azure"]');
+    if (azureOption && !available.includes('azure')) {
+      azureOption.disabled = true;
+      if (providerSelect.value === 'azure') {
+        providerSelect.value = 'espeak';
+      }
+      if (providerHint) {
+        providerHint.textContent = 'Azure 未启用，请在 .env 配置密钥后重启服务端。';
+      }
+    }
+  } catch (error) {
+    console.warn('获取 provider 列表失败：', error);
+  }
+}
+
+initProviderAvailability();
+


### PR DESCRIPTION
## Summary
- integrate an eSpeak NG adapter that emits WAV audio plus viseme-driven mouth timelines, expose `/audio/:id` download route, and add temp file cleanup utilities
- refresh the web client with the BigMouthAvatar renderer, provider/render mode selectors, prioritized mouthTimeline playback, and supporting docs
- bootstrap a `weapp-stickbot` mini program that consumes the same timeline via `innerAudioContext`, plus expand architecture guidance and env samples

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc1283f644832897f4b97fe6ee6fa9