### PR TITLE
feat(core): add emotion pipeline (sentiment, prosody, expression mapping) and avatar expression support

### DIFF
--- a/packages/stickbot-core/src/avatar.bigmouth.ts
+++ b/packages/stickbot-core/src/avatar.bigmouth.ts
@@ -1,0 +1,490 @@
+/**
+ * @module avatar.bigmouth
+ * BigMouthAvatar（大嘴巴火柴人）在 Canvas 上绘制可动画的火柴人头像。
+ * 该版本为 TypeScript 实现，提供向量与 Sprite 两种绘制模式，并支持
+ * 通过 {@link BigMouthAvatar#setExpression} 注入情绪表情参数。
+ */
+
+import type { AvatarExpressionParams } from './emotion/expression-mapping.js';
+
+/**
+ * BigMouthAvatar 的配置项。
+ */
+export interface AvatarConfig {
+  /** 眨眼间隔范围（秒）。 */
+  blinkIntervalRange: [number, number];
+  /** 单次眨眼时长（秒）。 */
+  blinkDuration: number;
+  /** 四肢摆动幅度（弧度）。 */
+  limbSwingAmplitude: number;
+  /** 四肢摆动速度倍数。 */
+  limbSwingSpeed: number;
+  /** mouth 数值平滑系数（0-1）。 */
+  mouthSmoothing: number;
+  /** Sprite 模式资源根路径。 */
+  spriteBasePath: string;
+  /** 预加载 Sprite 的最大口型编号。 */
+  spriteMaxViseme: number;
+}
+
+/** 默认配置。 */
+export const DEFAULT_CONFIG: AvatarConfig = {
+  blinkIntervalRange: [2.4, 5.2],
+  blinkDuration: 0.18,
+  limbSwingAmplitude: 0.22,
+  limbSwingSpeed: 1.5,
+  mouthSmoothing: 0.2,
+  spriteBasePath: './assets/mouth',
+  spriteMaxViseme: 12,
+};
+
+/** 渲染模式。 */
+export type RenderMode = 'vector' | 'sprite';
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const nowMs = (): number => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+const nowSeconds = (): number => nowMs() / 1000;
+
+const randomBlinkTime = (
+  range: [number, number],
+  bias = 0,
+): number => {
+  const [min, max] = range;
+  const span = max - min;
+  const biasedSpan = span * clamp(1 - bias * 0.6, 0.3, 1.6);
+  const offset = Math.random() * biasedSpan;
+  return nowSeconds() + min * clamp(1 - bias * 0.5, 0.4, 1.6) + offset;
+};
+
+const defaultExpressionState = (): AvatarExpressionParams => ({
+  mouthOpenScale: 1,
+  lipTension: 0,
+  cornerCurve: 0,
+  eyeBlinkBias: 0,
+  headNodAmp: 0,
+  swayAmp: 0,
+});
+
+let fallbackRafId = 0;
+const fallbackTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+const requestFrame = (callback: FrameRequestCallback): number => {
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    return window.requestAnimationFrame(callback);
+  }
+  fallbackRafId += 1;
+  const handle = fallbackRafId;
+  const timer = setTimeout(() => {
+    fallbackTimers.delete(handle);
+    callback(nowMs());
+  }, 16);
+  fallbackTimers.set(handle, timer);
+  return handle;
+};
+
+const cancelFrame = (handle: number): void => {
+  if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+    window.cancelAnimationFrame(handle);
+    return;
+  }
+  const timer = fallbackTimers.get(handle);
+  if (timer) {
+    clearTimeout(timer);
+    fallbackTimers.delete(handle);
+  }
+};
+
+/**
+ * mouth 帧数据。
+ */
+export interface MouthFrame {
+  /** mouth 数值，0-1。 */
+  value: number;
+  /** 口型 viseme 标识。 */
+  visemeId?: number;
+  /** 可选音素描述。 */
+  phoneme?: string;
+}
+
+/** Sprite 配置。 */
+export interface SpriteOptions {
+  /** 图片基路径。 */
+  basePath?: string;
+  /** 最大口型编号。 */
+  maxViseme?: number;
+}
+
+/**
+ * 可在 Canvas 上绘制火柴人大嘴巴头像的类。
+ */
+export class BigMouthAvatar {
+  private readonly canvas: HTMLCanvasElement;
+
+  private readonly ctx: CanvasRenderingContext2D | null;
+
+  private readonly config: AvatarConfig;
+
+  private currentMouth = 0.1;
+
+  private targetMouth = 0.1;
+
+  private currentViseme = 0;
+
+  private targetViseme = 0;
+
+  private currentPhoneme = 'idle';
+
+  private rafId: number | null = null;
+
+  private lastTimestamp = 0;
+
+  private nextBlinkTime = 0;
+
+  private blinkProgress = 0;
+
+  private renderMode: RenderMode = 'vector';
+
+  private spriteFrames: (HTMLImageElement | undefined)[] = [];
+
+  private spriteLoaded = false;
+
+  private expression: AvatarExpressionParams = defaultExpressionState();
+
+  private headNodPhase = Math.random() * Math.PI * 2;
+
+  private swayPhase = Math.random() * Math.PI * 2;
+
+  /**
+   * @param canvas - 目标画布。
+   * @param config - 可选配置覆盖。
+   */
+  constructor(canvas: HTMLCanvasElement, config: Partial<AvatarConfig> = {}) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.nextBlinkTime = randomBlinkTime(this.config.blinkIntervalRange);
+  }
+
+  /** 启动动画循环。 */
+  start(): void {
+    if (this.rafId !== null) return;
+    const loop = (timestamp: number) => {
+      this.update(timestamp);
+      this.draw();
+      this.rafId = requestFrame(loop);
+    };
+    this.rafId = requestFrame(loop);
+  }
+
+  /** 停止动画循环。 */
+  stop(): void {
+    if (this.rafId !== null) {
+      cancelFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  /**
+   * 更新目标 mouth 帧。
+   *
+   * @param frame - mouth 帧数据。
+   */
+  setMouthFrame(frame: MouthFrame): void {
+    this.targetMouth = clamp(frame.value, 0, 1);
+    this.targetViseme = frame.visemeId ?? 0;
+    this.currentPhoneme = frame.phoneme ?? 'unknown';
+  }
+
+  /**
+   * 调整当前的表情参数。
+   *
+   * @param params - 需要覆盖的表情字段。
+   */
+  setExpression(params: Partial<AvatarExpressionParams> = {}): void {
+    this.expression = {
+      ...this.expression,
+      ...params,
+    };
+    this.expression.mouthOpenScale = clamp(this.expression.mouthOpenScale, 0.5, 2.5);
+    this.expression.lipTension = clamp(this.expression.lipTension, -1, 1);
+    this.expression.cornerCurve = clamp(this.expression.cornerCurve, -1, 1);
+    this.expression.eyeBlinkBias = clamp(this.expression.eyeBlinkBias, -1, 1);
+    this.expression.headNodAmp = clamp(this.expression.headNodAmp, 0, 1.2);
+    this.expression.swayAmp = clamp(this.expression.swayAmp, 0, 1);
+  }
+
+  /**
+   * 手动切换渲染模式。
+   *
+   * @param mode - 目标渲染模式。
+   * @returns 是否切换成功。
+   */
+  async setRenderMode(mode: RenderMode): Promise<boolean> {
+    if (mode === 'sprite') {
+      const ok = await this.ensureSprites();
+      if (!ok) {
+        this.renderMode = 'vector';
+        return false;
+      }
+    }
+    this.renderMode = mode;
+    return true;
+  }
+
+  /**
+   * 自定义 Sprite 资源目录与数量。
+   */
+  configureSprite(options: SpriteOptions): void {
+    if (options.basePath) {
+      this.config.spriteBasePath = options.basePath;
+      this.spriteLoaded = false;
+      this.spriteFrames = [];
+    }
+    if (typeof options.maxViseme === 'number') {
+      this.config.spriteMaxViseme = options.maxViseme;
+      this.spriteLoaded = false;
+      this.spriteFrames = [];
+    }
+  }
+
+  private async ensureSprites(): Promise<boolean> {
+    if (this.spriteLoaded) {
+      return this.spriteFrames.length > 0;
+    }
+    this.spriteFrames = [];
+    for (let i = 0; i <= this.config.spriteMaxViseme; i += 1) {
+      // eslint-disable-next-line no-await-in-loop -- 顺序加载便于失败时提前中断
+      const image = await this.loadSpriteImage(`${this.config.spriteBasePath}/v${i}.png`);
+      if (image) {
+        this.spriteFrames[i] = image;
+      } else if (i === 0) {
+        break;
+      }
+    }
+    this.spriteLoaded = true;
+    return this.spriteFrames.length > 0;
+  }
+
+  private loadSpriteImage(url: string): Promise<HTMLImageElement | null> {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => resolve(null);
+      img.src = url;
+    });
+  }
+
+  private update(timestamp: number): void {
+    if (!this.lastTimestamp) {
+      this.lastTimestamp = timestamp;
+    }
+    const delta = (timestamp - this.lastTimestamp) / 1000;
+    this.lastTimestamp = timestamp;
+
+    const smoothing = this.config.mouthSmoothing;
+    const blendFactor = 1 - Math.pow(1 - smoothing, delta * 60);
+    this.currentMouth += (this.targetMouth - this.currentMouth) * blendFactor;
+    this.currentViseme += (this.targetViseme - this.currentViseme) * blendFactor;
+
+    const now = timestamp / 1000;
+    const blinkBias = this.expression.eyeBlinkBias;
+    if (now >= this.nextBlinkTime) {
+      this.blinkProgress = Math.min(1, this.blinkProgress + delta / (this.config.blinkDuration / 2));
+      if (this.blinkProgress >= 1) {
+        this.nextBlinkTime = now + 0.12;
+      }
+    } else if (this.blinkProgress > 0) {
+      this.blinkProgress = Math.max(0, this.blinkProgress - delta / (this.config.blinkDuration / 2));
+      if (this.blinkProgress === 0) {
+        const intervalRange: [number, number] = [
+          this.config.blinkIntervalRange[0] * clamp(1 - blinkBias * 0.5, 0.4, 1.6),
+          this.config.blinkIntervalRange[1] * clamp(1 - blinkBias * 0.5, 0.4, 1.6),
+        ];
+        this.nextBlinkTime = randomBlinkTime(intervalRange, blinkBias);
+      }
+    }
+
+    this.headNodPhase += delta * (1.2 + this.expression.headNodAmp * 2.4);
+    this.swayPhase += delta * (1 + this.expression.swayAmp * 1.5);
+  }
+
+  private draw(): void {
+    const ctx = this.ctx;
+    if (!ctx) return;
+
+    const { width, height } = this.canvas;
+    ctx.clearRect(0, 0, width, height);
+
+    ctx.save();
+    ctx.translate(width / 2, height / 2 + 40);
+    ctx.lineCap = 'round';
+
+    this.drawBody(ctx);
+
+    if (this.renderMode === 'sprite' && this.spriteFrames.length > 0) {
+      this.drawSpriteHead(ctx);
+    } else {
+      this.drawVectorHead(ctx);
+    }
+
+    ctx.restore();
+  }
+
+  private drawBody(ctx: CanvasRenderingContext2D): void {
+    const time = nowSeconds();
+    const swayExtra = this.expression.swayAmp * 0.4;
+    const swing = Math.sin(time * this.config.limbSwingSpeed + this.swayPhase) * (this.config.limbSwingAmplitude + swayExtra);
+    const jitter = (Math.random() - 0.5) * 0.06 * (0.2 + this.currentMouth);
+
+    ctx.strokeStyle = '#1f2937';
+    ctx.lineWidth = 6;
+
+    ctx.beginPath();
+    ctx.moveTo(0, -120);
+    ctx.lineTo(0, 40);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(0, -80);
+    ctx.lineTo(-70, -80 + Math.sin(time * this.config.limbSwingSpeed + Math.PI / 4) * 32);
+    ctx.moveTo(0, -80);
+    ctx.lineTo(70, -80 + Math.sin(time * this.config.limbSwingSpeed + Math.PI + jitter) * 32);
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(0, 40);
+    ctx.lineTo(-50, 140 + swing * 40);
+    ctx.moveTo(0, 40);
+    ctx.lineTo(50, 140 - swing * 40);
+    ctx.stroke();
+  }
+
+  private drawVectorHead(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+
+    const nodOffset = Math.sin(this.headNodPhase) * (6 + this.expression.headNodAmp * 12);
+    const headY = -150 - this.currentMouth * 8 + nodOffset;
+    const headRadius = 48;
+
+    const mouthWidthBase = 70;
+    const mouthHeightBase = 8 + this.currentMouth * 48;
+    const mouthHeight = mouthHeightBase * this.expression.mouthOpenScale;
+    const visemeRounded = Math.round(this.currentViseme);
+    const roundedLip = visemeRounded === 9;
+    const widthFactor = roundedLip ? 0.65 : 1;
+    const lipTensionFactor = clamp(1 - this.expression.lipTension * 0.35, 0.5, 1.4);
+    const mouthWidth = mouthWidthBase * widthFactor * lipTensionFactor;
+
+    ctx.lineWidth = 5;
+    ctx.strokeStyle = '#111827';
+    ctx.fillStyle = '#f9fafb';
+    ctx.beginPath();
+    ctx.arc(0, headY, headRadius, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    const blinkAmount = clamp(this.blinkProgress + this.expression.eyeBlinkBias * 0.4, 0, 1);
+    const eyeGap = 20;
+    const eyeHeight = Math.max(2, 10 * (1 - blinkAmount));
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.moveTo(-eyeGap, headY - 12);
+    ctx.lineTo(-eyeGap, headY - 12 + eyeHeight);
+    ctx.moveTo(eyeGap, headY - 12);
+    ctx.lineTo(eyeGap, headY - 12 + eyeHeight);
+    ctx.stroke();
+
+    const lipTopY = headY + 18 - this.expression.cornerCurve * 10;
+    const lipBottomY = lipTopY + mouthHeight + this.expression.cornerCurve * 16;
+    const controlOffsetBase = mouthHeight * 0.7;
+    const controlOffset = controlOffsetBase * (1 + this.expression.cornerCurve * 0.4);
+
+    ctx.lineWidth = 6;
+    ctx.strokeStyle = '#ef4444';
+
+    ctx.beginPath();
+    ctx.moveTo(-mouthWidth, lipTopY);
+    ctx.bezierCurveTo(
+      -mouthWidth * 0.4,
+      lipTopY - controlOffset,
+      mouthWidth * 0.4,
+      lipTopY - controlOffset,
+      mouthWidth,
+      lipTopY,
+    );
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(-mouthWidth, lipBottomY);
+    ctx.bezierCurveTo(
+      -mouthWidth * 0.4,
+      lipBottomY + controlOffset,
+      mouthWidth * 0.4,
+      lipBottomY + controlOffset,
+      mouthWidth,
+      lipBottomY,
+    );
+    ctx.stroke();
+
+    ctx.fillStyle = '#7f1d1d';
+    ctx.beginPath();
+    ctx.moveTo(-mouthWidth + 3, lipTopY + 3);
+    ctx.bezierCurveTo(
+      -mouthWidth * 0.3,
+      lipTopY + 3 - controlOffset * 0.8,
+      mouthWidth * 0.3,
+      lipTopY + 3 - controlOffset * 0.8,
+      mouthWidth - 3,
+      lipTopY + 3,
+    );
+    ctx.lineTo(mouthWidth - 3, lipBottomY - 3);
+    ctx.bezierCurveTo(
+      mouthWidth * 0.3,
+      lipBottomY - 3 + controlOffset * 0.8,
+      -mouthWidth * 0.3,
+      lipBottomY - 3 + controlOffset * 0.8,
+      -mouthWidth + 3,
+      lipBottomY - 3,
+    );
+    ctx.closePath();
+    ctx.fill();
+
+    if (mouthHeight > 12) {
+      ctx.fillStyle = '#fefce8';
+      const toothCount = Math.min(6, Math.max(3, Math.floor(mouthWidth / 14)));
+      const toothWidth = (mouthWidth * 1.8) / toothCount / 2;
+      const toothHeight = Math.min(12, mouthHeight * 0.4);
+      for (let i = 0; i < toothCount; i += 1) {
+        const ratio = (i / (toothCount - 1)) * 2 - 1;
+        const x = ratio * mouthWidth * 0.7;
+        ctx.fillRect(x - toothWidth / 2, lipTopY + 2, toothWidth, toothHeight);
+      }
+    }
+
+    if (roundedLip) {
+      ctx.strokeStyle = '#fca5a5';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.ellipse(0, (lipTopY + lipBottomY) / 2, mouthWidth * 0.7, mouthHeight * 0.4, 0, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+
+  private drawSpriteHead(ctx: CanvasRenderingContext2D): void {
+    const headY = -180;
+    const image = this.spriteFrames[Math.round(this.currentViseme)] || this.spriteFrames[0];
+    if (!image) {
+      this.drawVectorHead(ctx);
+      return;
+    }
+    const scale = 1 + this.currentMouth * 0.1 * this.expression.mouthOpenScale;
+    const width = image.width * scale;
+    const height = image.height * scale;
+    ctx.drawImage(image, -width / 2, headY - height / 2, width, height);
+  }
+}

--- a/packages/stickbot-core/src/emotion/expression-mapping.ts
+++ b/packages/stickbot-core/src/emotion/expression-mapping.ts
@@ -1,0 +1,129 @@
+/**
+ * @module emotion/expression-mapping
+ * 根据情绪维度映射出头像需要的表情参数。
+ */
+
+import type { SentimentEstimate } from './sentiment-heuristics.js';
+
+/**
+ * BigMouthAvatar 可识别的表情参数集合。
+ */
+export interface AvatarExpressionParams {
+  /** 嘴巴张开倍数，1 为基准。 */
+  mouthOpenScale: number;
+  /** 嘴唇拉紧程度，0 表示放松，正值表示紧绷。 */
+  lipTension: number;
+  /** 嘴角弯曲程度，正值表示上扬。 */
+  cornerCurve: number;
+  /** 眨眼偏置，正值表示更频繁眨眼，负值表示保持睁眼。 */
+  eyeBlinkBias: number;
+  /** 轻点头幅度，数值越大动作越明显。 */
+  headNodAmp: number;
+  /** 身体轻微左右摇摆幅度。 */
+  swayAmp: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const defaultExpression: AvatarExpressionParams = {
+  mouthOpenScale: 1,
+  lipTension: 0,
+  cornerCurve: 0,
+  eyeBlinkBias: 0,
+  headNodAmp: 0,
+  swayAmp: 0,
+};
+
+const computeLipTension = (valence: number, arousal: number, tags: string[]): number => {
+  let tension = arousal * 0.4;
+  if (valence < -0.3) {
+    tension += Math.abs(valence) * 0.4;
+  }
+  if (tags.includes('shouting')) {
+    tension += 0.2;
+  }
+  if (tags.includes('calm')) {
+    tension *= 0.6;
+  }
+  return clamp(tension, 0, 1);
+};
+
+const computeCornerCurve = (valence: number, tags: string[]): number => {
+  let curve = valence * 0.6;
+  if (tags.includes('mixed')) {
+    curve *= 0.5;
+  }
+  if (tags.includes('question')) {
+    curve -= 0.1;
+  }
+  return clamp(curve, -1, 1);
+};
+
+const computeBlinkBias = (arousal: number, tags: string[]): number => {
+  let bias = -arousal * 0.3;
+  if (tags.includes('calm')) {
+    bias += 0.2;
+  }
+  if (tags.includes('shouting') || tags.includes('excited')) {
+    bias -= 0.2;
+  }
+  return clamp(bias, -0.6, 0.6);
+};
+
+const computeHeadNod = (valence: number, tags: string[]): number => {
+  let nod = Math.max(0, valence) * 0.5;
+  if (tags.includes('question')) {
+    nod += 0.2;
+  }
+  if (tags.includes('negative')) {
+    nod *= 0.4;
+  }
+  return clamp(nod, 0, 1);
+};
+
+const computeSway = (arousal: number, tags: string[]): number => {
+  let sway = 0.1 + arousal * 0.2;
+  if (tags.includes('calm')) {
+    sway *= 0.6;
+  }
+  if (tags.includes('excited')) {
+    sway += 0.1;
+  }
+  return clamp(sway, 0, 0.6);
+};
+
+/**
+ * 将情绪估计结果映射为 BigMouthAvatar 的表情参数。
+ *
+ * 该映射遵循以下直觉：
+ * - arousal 越高嘴巴张开越明显，同时身体摇摆幅度更大；
+ * - valence 越高嘴角越上扬，越低嘴角越下压；
+ * - 负向情绪与高激动会提升嘴唇紧绷；
+ * - calm/question 等标签会微调眨眼与点头。
+ *
+ * @param emotion - 情绪估计结果，可以只提供 valence 与 arousal。
+ * @returns {@link AvatarExpressionParams} 可直接应用于 {@link BigMouthAvatar#setExpression} 的表情参数。
+ */
+export function mapEmotionToExpression(emotion: Partial<SentimentEstimate>): AvatarExpressionParams {
+  const valence = clamp(emotion.valence ?? 0, -1, 1);
+  const arousal = clamp(emotion.arousal ?? 0.4, 0, 1);
+  const tags = emotion.tags ?? [];
+
+  const mouthOpenScale = clamp(0.9 + arousal * 0.6 + valence * 0.1, 0.6, 1.8);
+  const lipTension = computeLipTension(valence, arousal, tags);
+  const cornerCurve = computeCornerCurve(valence, tags);
+  const eyeBlinkBias = computeBlinkBias(arousal, tags);
+  const headNodAmp = computeHeadNod(valence, tags);
+  const swayAmp = computeSway(arousal, tags);
+
+  return {
+    ...defaultExpression,
+    mouthOpenScale,
+    lipTension,
+    cornerCurve,
+    eyeBlinkBias,
+    headNodAmp,
+    swayAmp,
+  };
+}

--- a/packages/stickbot-core/src/emotion/prosody-hints.ts
+++ b/packages/stickbot-core/src/emotion/prosody-hints.ts
@@ -1,0 +1,168 @@
+/**
+ * @module emotion/prosody-hints
+ * 根据文本标点生成表情时间线提示，用于强化语音节奏。
+ */
+
+import type { ExpressionTimelineKeyframe } from '../timeline-player.js';
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const WORD_REGEX = /[\p{L}\p{N}'][\p{L}\p{N}'-]*/gu;
+const WORD_TOKEN_REGEX = /^[\p{L}\p{N}'][\p{L}\p{N}'-]*$/u;
+const TOKEN_REGEX = /[\p{L}\p{N}']+[\p{L}\p{N}'-]*|\.\.\.|[^\s]/gu;
+
+const BASE_STATE: Record<string, number> = {
+  mouthOpenScale: 1,
+  lipTension: 0,
+  cornerCurve: 0,
+  eyeBlinkBias: 0,
+  headNodAmp: 0,
+  swayAmp: 0.12,
+};
+
+/**
+ * `deriveProsodyHints` 的可选配置。
+ */
+export interface ProsodyHintOptions {
+  /** 每个词语的平均时长（秒），默认 0.32。 */
+  wordDuration?: number;
+  /** 表情恢复到基线的缓冲时长（秒），默认 0.35。 */
+  releaseDuration?: number;
+}
+
+const pushReturnKeyframe = (
+  timeline: ExpressionTimelineKeyframe[],
+  key: string,
+  time: number,
+  releaseDuration: number,
+): void => {
+  const targetTime = time + releaseDuration;
+  timeline.push({ t: targetTime, k: key, v: BASE_STATE[key] ?? 0 });
+};
+
+const addEmphasis = (
+  timeline: ExpressionTimelineKeyframe[],
+  time: number,
+  key: keyof typeof BASE_STATE,
+  value: number,
+  release: number,
+): void => {
+  timeline.push({ t: time, k: key, v: value });
+  pushReturnKeyframe(timeline, key, time, release);
+};
+
+const handleSentenceEnd = (
+  timeline: ExpressionTimelineKeyframe[],
+  time: number,
+  punctuation: string,
+  release: number,
+): void => {
+  if (punctuation === '!') {
+    addEmphasis(timeline, time, 'mouthOpenScale', 1.4, release + 0.1);
+    addEmphasis(timeline, time, 'lipTension', 0.5, release + 0.1);
+    addEmphasis(timeline, time, 'eyeBlinkBias', -0.2, release);
+  } else if (punctuation === '?') {
+    addEmphasis(timeline, time, 'mouthOpenScale', 1.25, release);
+    addEmphasis(timeline, time, 'headNodAmp', 0.35, release + 0.1);
+    addEmphasis(timeline, time, 'cornerCurve', -0.15, release);
+  } else {
+    addEmphasis(timeline, time, 'mouthOpenScale', 0.85, release);
+    addEmphasis(timeline, time, 'headNodAmp', 0.22, release);
+    addEmphasis(timeline, time, 'eyeBlinkBias', 0.25, release);
+  }
+};
+
+const handlePause = (
+  timeline: ExpressionTimelineKeyframe[],
+  time: number,
+  punctuation: string,
+  release: number,
+): void => {
+  if (punctuation === ',') {
+    addEmphasis(timeline, time, 'mouthOpenScale', 1.1, release);
+    addEmphasis(timeline, time, 'headNodAmp', 0.18, release);
+  } else if (punctuation === ';' || punctuation === ':') {
+    addEmphasis(timeline, time, 'mouthOpenScale', 0.95, release);
+    addEmphasis(timeline, time, 'lipTension', 0.25, release);
+  } else if (punctuation === '…' || punctuation === '...') {
+    addEmphasis(timeline, time, 'mouthOpenScale', 0.7, release + 0.2);
+    addEmphasis(timeline, time, 'eyeBlinkBias', 0.3, release + 0.1);
+  }
+};
+
+const addBaseline = (timeline: ExpressionTimelineKeyframe[]): void => {
+  for (const [key, value] of Object.entries(BASE_STATE)) {
+    timeline.push({ t: 0, k: key, v: value });
+  }
+};
+
+const isWord = (token: string): boolean => WORD_TOKEN_REGEX.test(token);
+
+const estimateWordDuration = (token: string, baseDuration: number): number => {
+  if (!isWord(token)) return baseDuration;
+  const extra = clamp(token.length - 3, 0, 10) * 0.02;
+  return baseDuration + extra;
+};
+
+/**
+ * 根据文本标点生成 expressionTimeline，用于在语音播放过程中驱动额外表情。
+ *
+ * 函数会对输入文本执行一次粗略的节奏估计：
+ * - 每个词给予固定时间增量；
+ * - 逗号/分号等作为短暂停顿；
+ * - 句号/感叹号/问号作为句末强调；
+ * - 省略号会触发更明显的眨眼与嘴部收拢。
+ *
+ * 返回的时间线仅包含关键点，后续可在 {@link TimelinePlayer} 中按需插值。
+ *
+ * @param text - 输入文本。
+ * @param options - 可选配置，例如词时长与恢复时长。
+ * @returns {@link ExpressionTimelineKeyframe[]} 表情关键帧序列。
+ */
+export function deriveProsodyHints(
+  text: string,
+  options: ProsodyHintOptions = {},
+): ExpressionTimelineKeyframe[] {
+  const releaseDuration = options.releaseDuration ?? 0.35;
+  const wordDuration = options.wordDuration ?? 0.32;
+  const timeline: ExpressionTimelineKeyframe[] = [];
+  addBaseline(timeline);
+
+  const tokens = text.match(TOKEN_REGEX) ?? [];
+  let time = 0;
+
+  for (const token of tokens) {
+    if (isWord(token)) {
+      time += estimateWordDuration(token, wordDuration);
+      continue;
+    }
+
+    if (/^\s+$/.test(token)) {
+      time += token.length * 0.05;
+      continue;
+    }
+
+    const normalized = token === '...' ? '...' : token;
+    if (normalized === '...' || normalized === '…') {
+      handlePause(timeline, time, normalized, releaseDuration + 0.1);
+      time += releaseDuration + 0.15;
+      continue;
+    }
+
+    if (',;:'.includes(normalized)) {
+      handlePause(timeline, time, normalized, releaseDuration);
+      time += releaseDuration * 0.8;
+      continue;
+    }
+
+    if ('.?!'.includes(normalized)) {
+      handleSentenceEnd(timeline, time, normalized, releaseDuration + 0.05);
+      time += releaseDuration + 0.2;
+      continue;
+    }
+  }
+
+  timeline.sort((a, b) => a.t - b.t);
+  return timeline;
+}

--- a/packages/stickbot-core/src/emotion/sentiment-heuristics.ts
+++ b/packages/stickbot-core/src/emotion/sentiment-heuristics.ts
@@ -1,0 +1,164 @@
+/**
+ * @module emotion/sentiment-heuristics
+ * 提供基于启发式规则的文本情绪估计。
+ */
+
+/**
+ * 情绪估计结果。
+ */
+export interface SentimentEstimate {
+  /**
+   * 感情极性（valence），-1 表示非常负面，1 表示非常正面。
+   */
+  valence: number;
+  /**
+   * 激动程度（arousal），0 表示非常平静，1 表示高度激动。
+   */
+  arousal: number;
+  /**
+   * 与输入文本相关的标签集合，例如 `positive`、`question`。
+   */
+  tags: string[];
+}
+
+const POSITIVE_WORDS = [
+  'good',
+  'great',
+  'love',
+  'nice',
+  'happy',
+  'awesome',
+  'amazing',
+  'cool',
+  'yay',
+  'thanks',
+  'thank you',
+  'bravo',
+  'fantastic',
+  'wonderful',
+];
+
+const NEGATIVE_WORDS = [
+  'bad',
+  'sad',
+  'angry',
+  'upset',
+  'hate',
+  'terrible',
+  'awful',
+  'no',
+  'never',
+  'wtf',
+  'mad',
+  'annoyed',
+  'tired',
+  'worried',
+];
+
+const INTENSIFIERS = ['very', 'super', 'really', 'extremely', 'so', 'too'];
+const CALM_WORDS = ['calm', 'gentle', 'relax', 'quiet', 'slow'];
+const EXCITED_WORDS = ['excited', 'hype', 'wow', '!!!', 'whoa'];
+
+const WORD_REGEX = /[\p{L}\p{N}'][\p{L}\p{N}'-]*/gu;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const countMatches = (text: string, dictionary: string[]): number => {
+  let count = 0;
+  for (const word of dictionary) {
+    if (text.includes(word)) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+const wordScore = (word: string, dictionary: string[]): number =>
+  dictionary.some((entry) => word.includes(entry)) ? 1 : 0;
+
+const applyIntensity = (baseScore: number, intensifierCount: number): number => {
+  if (!intensifierCount) return baseScore;
+  const boost = 1 + intensifierCount * 0.35;
+  return baseScore * boost;
+};
+
+const detectTags = (text: string, valence: number, arousal: number, polarityScore: number): string[] => {
+  const tags = new Set<string>();
+  if (valence > 0.25) {
+    tags.add('positive');
+  } else if (valence < -0.25) {
+    tags.add('negative');
+  }
+  if (polarityScore > 1.5 && Math.abs(valence) < 0.35) {
+    tags.add('mixed');
+  }
+  if (text.includes('?')) {
+    tags.add('question');
+  }
+  const exclamations = (text.match(/!/g) || []).length;
+  if (exclamations >= 2 || /([A-Z]{3,}\b)/.test(text)) {
+    tags.add('shouting');
+  }
+  if (arousal > 0.7) {
+    tags.add('excited');
+  } else if (arousal < 0.3) {
+    tags.add('calm');
+  }
+  return [...tags];
+};
+
+/**
+ * 基于启发式规则估计输入文本的情绪状态。
+ *
+ * 该函数会结合积极/消极词汇、感叹号数量、大小写与强化词汇等信息，
+ * 返回一个简单的情绪估计结果。虽然无法覆盖所有语境，但在无模型依赖
+ * 的场景下能够提供可用的基线值。
+ *
+ * @param text - 待分析的文本内容。
+ * @returns {@link SentimentEstimate} 情绪估计结果。
+ */
+export function estimateSentiment(text: string): SentimentEstimate {
+  const normalized = text.toLowerCase();
+  const tokens = normalized.match(WORD_REGEX) || [];
+
+  let positive = 0;
+  let negative = 0;
+  let intensifiers = 0;
+  let calmHints = 0;
+  let excitedHints = 0;
+
+  for (const token of tokens) {
+    positive += wordScore(token, POSITIVE_WORDS);
+    negative += wordScore(token, NEGATIVE_WORDS);
+    intensifiers += wordScore(token, INTENSIFIERS);
+    calmHints += wordScore(token, CALM_WORDS);
+    excitedHints += wordScore(token, EXCITED_WORDS);
+  }
+
+  const punctuationExcitement = (text.match(/[!¡❗]/g) || []).length * 0.25;
+  const questionMarks = (text.match(/\?/g) || []).length;
+  const uppercaseIntensity = countMatches(text, ['LOL', 'OMG', 'WOW']);
+
+  const polarityRaw = positive - negative;
+  const polarityMagnitude = Math.abs(positive) + Math.abs(negative);
+  const polarityAdjusted = applyIntensity(polarityRaw, intensifiers);
+  const valence = clamp(
+    polarityMagnitude === 0 ? 0 : polarityAdjusted / (polarityMagnitude + 0.5),
+    -1,
+    1,
+  );
+
+  const calmFactor = calmHints * 0.15;
+  const excitedFactor = excitedHints * 0.15 + punctuationExcitement + uppercaseIntensity * 0.2;
+  const baseArousal = 0.25 + Math.abs(valence) * 0.3 + excitedFactor;
+  const arousal = clamp(baseArousal - calmFactor + questionMarks * 0.05, 0, 1);
+
+  const tags = detectTags(text, valence, arousal, Math.abs(polarityRaw));
+
+  return {
+    valence,
+    arousal,
+    tags,
+  };
+}

--- a/packages/stickbot-core/src/index.ts
+++ b/packages/stickbot-core/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @module stickbot-core
+ * 核心导出：包含 Avatar、时间线播放器与情绪工具。
+ */
+
+export { BigMouthAvatar, DEFAULT_CONFIG } from './avatar.bigmouth.js';
+export type { AvatarConfig, MouthFrame, RenderMode, SpriteOptions } from './avatar.bigmouth.js';
+
+export { TimelinePlayer } from './timeline-player.js';
+export type {
+  MouthTimelineFrame,
+  ExpressionTimelineKeyframe,
+  TimelinePlayerFrame,
+  TimelinePlayerOptions,
+} from './timeline-player.js';
+
+export { estimateSentiment } from './emotion/sentiment-heuristics.js';
+export type { SentimentEstimate } from './emotion/sentiment-heuristics.js';
+
+export { deriveProsodyHints } from './emotion/prosody-hints.js';
+export type { ProsodyHintOptions } from './emotion/prosody-hints.js';
+export type { ExpressionTimelinePoint } from './timeline-player.js';
+
+export { mapEmotionToExpression } from './emotion/expression-mapping.js';
+export type { AvatarExpressionParams } from './emotion/expression-mapping.js';

--- a/packages/stickbot-core/src/timeline-player.ts
+++ b/packages/stickbot-core/src/timeline-player.ts
@@ -1,0 +1,279 @@
+/**
+ * @module timeline-player
+ * 提供用于驱动嘴型与表情的时间线播放器。
+ */
+
+import type { AvatarExpressionParams } from './emotion/expression-mapping.js';
+
+/**
+ * 单个 mouth 关键帧。
+ */
+export interface MouthTimelineFrame {
+  /** 时间戳（秒）。 */
+  t: number;
+  /** mouth 数值，0-1。 */
+  value: number;
+  /** 可选的 viseme 标识，用于 Sprite 口型切换。 */
+  visemeId?: number;
+  /** 可选的音素标签，仅用于调试或日志。 */
+  phoneme?: string;
+}
+
+/**
+ * 表情时间线关键帧。
+ */
+export interface ExpressionTimelineKeyframe {
+  /** 时间戳（秒）。 */
+  t: number;
+  /** 表情键，例如 `mouthOpenScale`、`headNodAmp`。 */
+  k: keyof AvatarExpressionParams | string;
+  /** 目标值。 */
+  v: number;
+}
+
+/**
+ * {@link TimelinePlayer} 配置项。
+ */
+export interface TimelinePlayerOptions {
+  /**
+   * mouth 数值的平滑系数，0 表示无平滑，1 表示完全跟随上一帧。
+   * 默认 0.22。
+   */
+  smoothing?: number;
+  /** 额外的表情关键帧列表。 */
+  expressionTimeline?: ExpressionTimelineKeyframe[];
+  /** 表情整体强度缩放，默认 1。 */
+  expressionScale?: number;
+}
+
+/**
+ * {@link TimelinePlayer#getFrameAt} 返回的结果。
+ */
+export interface TimelinePlayerFrame {
+  /** mouth 数值，包含 expressionTimeline 的影响。 */
+  value: number;
+  /** 线性插值后的 viseme，便于做渐变。 */
+  visemeId: number;
+  /** 可选的音素标签。 */
+  phoneme?: string;
+  /** 当前表情参数。 */
+  expression: AvatarExpressionParams;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const DEFAULT_EXPRESSION: AvatarExpressionParams = {
+  mouthOpenScale: 1,
+  lipTension: 0,
+  cornerCurve: 0,
+  eyeBlinkBias: 0,
+  headNodAmp: 0,
+  swayAmp: 0,
+};
+
+const clampExpressionState = (
+  expression: AvatarExpressionParams,
+): AvatarExpressionParams => ({
+  mouthOpenScale: clamp(expression.mouthOpenScale, 0.2, 3),
+  lipTension: clamp(expression.lipTension, -1, 1),
+  cornerCurve: clamp(expression.cornerCurve, -1, 1),
+  eyeBlinkBias: clamp(expression.eyeBlinkBias, -1, 1),
+  headNodAmp: clamp(expression.headNodAmp, 0, 2),
+  swayAmp: clamp(expression.swayAmp, 0, 2),
+});
+
+const scaleExpression = (
+  expression: AvatarExpressionParams,
+  scale: number,
+): AvatarExpressionParams =>
+  clampExpressionState({
+    mouthOpenScale: 1 + (expression.mouthOpenScale - 1) * scale,
+    lipTension: expression.lipTension * scale,
+    cornerCurve: expression.cornerCurve * scale,
+    eyeBlinkBias: expression.eyeBlinkBias * scale,
+    headNodAmp: expression.headNodAmp * scale,
+    swayAmp: expression.swayAmp * scale,
+  });
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+const groupExpressionKeyframes = (
+  keyframes: ExpressionTimelineKeyframe[],
+): Map<string, ExpressionTimelineKeyframe[]> => {
+  const result = new Map<string, ExpressionTimelineKeyframe[]>();
+  for (const frame of keyframes) {
+    const list = result.get(frame.k) ?? [];
+    list.push(frame);
+    result.set(frame.k, list);
+  }
+  for (const [, list] of result) {
+    list.sort((a, b) => a.t - b.t);
+  }
+  return result;
+};
+
+const sampleKeyframes = (
+  frames: ExpressionTimelineKeyframe[],
+  time: number,
+  defaultValue: number,
+): number => {
+  if (!frames || frames.length === 0) return defaultValue;
+  if (time <= frames[0].t) {
+    return frames[0].v;
+  }
+  if (time >= frames[frames.length - 1].t) {
+    return frames[frames.length - 1].v;
+  }
+  for (let i = 0; i < frames.length - 1; i += 1) {
+    const current = frames[i];
+    const next = frames[i + 1];
+    if (time >= current.t && time <= next.t) {
+      const span = next.t - current.t || 1;
+      const factor = clamp((time - current.t) / span, 0, 1);
+      return lerp(current.v, next.v, factor);
+    }
+  }
+  return defaultValue;
+};
+
+const sampleMouthFrame = (
+  timeline: MouthTimelineFrame[],
+  time: number,
+): { value: number; visemeId: number; phoneme?: string } => {
+  if (timeline.length === 0) {
+    return { value: 0, visemeId: 0 };
+  }
+  if (time <= timeline[0].t) {
+    const first = timeline[0];
+    return {
+      value: first.value,
+      visemeId: first.visemeId ?? 0,
+      phoneme: first.phoneme,
+    };
+  }
+  if (time >= timeline[timeline.length - 1].t) {
+    const last = timeline[timeline.length - 1];
+    return {
+      value: last.value,
+      visemeId: last.visemeId ?? 0,
+      phoneme: last.phoneme,
+    };
+  }
+  for (let i = 0; i < timeline.length - 1; i += 1) {
+    const current = timeline[i];
+    const next = timeline[i + 1];
+    if (time >= current.t && time <= next.t) {
+      const span = next.t - current.t || 1;
+      const factor = clamp((time - current.t) / span, 0, 1);
+      const value = lerp(current.value, next.value, factor);
+      const viseme = lerp(current.visemeId ?? 0, next.visemeId ?? 0, factor);
+      const phoneme = factor > 0.5 ? next.phoneme ?? current.phoneme : current.phoneme;
+      return { value, visemeId: viseme, phoneme };
+    }
+  }
+  const fallback = timeline[timeline.length - 1];
+  return {
+    value: fallback.value,
+    visemeId: fallback.visemeId ?? 0,
+    phoneme: fallback.phoneme,
+  };
+};
+
+/**
+ * mouth 与表情时间线播放器。
+ *
+ * 使用方式：
+ * ```ts
+ * const player = new TimelinePlayer(mouthFrames, {
+ *   expressionTimeline: deriveProsodyHints(text),
+ * });
+ * const state = player.getFrameAt(1.2);
+ * avatar.setMouthFrame(state);
+ * avatar.setExpression(state.expression);
+ * ```
+ */
+export class TimelinePlayer {
+  private readonly mouthTimeline: MouthTimelineFrame[];
+
+  private readonly expressionTimeline: Map<string, ExpressionTimelineKeyframe[]>;
+
+  private readonly smoothing: number;
+
+  private readonly expressionScale: number;
+
+  private smoothedValue: number | null = null;
+
+  private lastSampleTime: number | null = null;
+
+  constructor(
+    mouthTimeline: MouthTimelineFrame[],
+    options: TimelinePlayerOptions = {},
+  ) {
+    this.mouthTimeline = [...mouthTimeline].sort((a, b) => a.t - b.t);
+    this.expressionTimeline = groupExpressionKeyframes(options.expressionTimeline ?? []);
+    this.smoothing = clamp(options.smoothing ?? 0.22, 0, 0.95);
+    this.expressionScale = clamp(options.expressionScale ?? 1, 0, 3);
+  }
+
+  /**
+   * 重置内部平滑状态，适用于跳播或重新开始播放。
+   */
+  reset(): void {
+    this.smoothedValue = null;
+    this.lastSampleTime = null;
+  }
+
+  /**
+   * 计算给定时间点的嘴型与表情状态。
+   *
+   * @param time - 目标时间（秒）。
+   * @returns {@link TimelinePlayerFrame} 包含口型、viseme 与表情的状态。
+   */
+  getFrameAt(time: number): TimelinePlayerFrame {
+    const { value: rawValue, visemeId, phoneme } = sampleMouthFrame(this.mouthTimeline, time);
+    const smoothed = this.applySmoothing(rawValue, time);
+    const expression = this.sampleExpression(time);
+    const scaledExpression = scaleExpression(expression, this.expressionScale);
+    const finalValue = clamp(smoothed * scaledExpression.mouthOpenScale, 0, 1);
+
+    return {
+      value: finalValue,
+      visemeId,
+      phoneme,
+      expression: scaledExpression,
+    };
+  }
+
+  private applySmoothing(value: number, time: number): number {
+    if (this.smoothedValue === null || this.lastSampleTime === null || time < this.lastSampleTime) {
+      this.smoothedValue = value;
+      this.lastSampleTime = time;
+      return value;
+    }
+    const delta = Math.max(time - this.lastSampleTime, 0);
+    this.lastSampleTime = time;
+    if (this.smoothing <= 0 || delta === 0) {
+      this.smoothedValue = value;
+      return value;
+    }
+    const factor = 1 - Math.pow(1 - this.smoothing, delta * 60);
+    this.smoothedValue += (value - this.smoothedValue) * factor;
+    return this.smoothedValue;
+  }
+
+  private sampleExpression(time: number): AvatarExpressionParams {
+    if (this.expressionTimeline.size === 0) {
+      return { ...DEFAULT_EXPRESSION };
+    }
+    const result: AvatarExpressionParams = { ...DEFAULT_EXPRESSION };
+    for (const [key, frames] of this.expressionTimeline) {
+      const defaultValue = (DEFAULT_EXPRESSION as Record<string, number>)[key] ?? 0;
+      const value = sampleKeyframes(frames, time, defaultValue);
+      (result as Record<string, number>)[key] = value;
+    }
+    return clampExpressionState(result);
+  }
+}
+
+export type { ExpressionTimelineKeyframe as ExpressionTimelinePoint };


### PR DESCRIPTION
## Summary
- add heuristic sentiment analysis, prosody hint generator, and emotion-to-expression mapping utilities
- extend BigMouthAvatar with expression controls and animation influences
- enhance TimelinePlayer to blend expression timelines and export new APIs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc66064fc0832895ab1aa88daa745c