### PR TITLE
feat(web): add Tuner page with real-time parameter control and curve overlay

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -5,6 +5,7 @@
 ## 目录结构
 
 - **`index.html`**：页面骨架与样式，包含渲染模式、TTS 供应器选择等控件。
+- **`tuner.html`**：可视化调参面板 Tuner，提供参数滑条、曲线叠加与 JSON 导入导出。
 - **`js/main.js`**：入口脚本，负责：
   - 根据用户输入调用服务端 `/tts`，优先消费 `mouthTimeline`；
   - 管理 Web Speech / 音量包络回退，并处理停止逻辑；
@@ -57,4 +58,21 @@ web/
 2. 在控制面板查看 `TTS 供应器` 选项，确认服务端返回的 `mouthTimeline` 是否生效（控制台会输出 `[stickbot] 使用服务端时间轴驱动口型。`）。
 3. 切换渲染模式观察差异，若 Sprite 未加载成功，会有提示信息。
 4. 开发自定义口型映射时，可在控制台打印 `viseme` 与 `phoneme`（`main.js` 已在进度条旁显示）。
+
+## 可视化调参面板 Tuner
+
+- 通过 `tuner.html` 打开调参页面：左侧为火柴人预览与 mouth 曲线叠加，右侧提供以下参数滑条：
+  - `mouthOpenScale`：嘴巴张开倍数，用于放大整体口型；
+  - `lipTension`：嘴唇收紧程度；
+  - `cornerCurve`：嘴角弯曲程度，正值上扬、负值下压；
+  - `eyeBlinkBias`：眨眼偏置，影响眨眼频率；
+  - `headNodAmp`：点头动作幅度；
+  - `swayAmp`：身体左右摆动幅度；
+  - `emaAlpha`：口型 EMA 平滑系数；
+  - `tickHz`：时间轴采样频率；
+  - `roundLipCompress`：圆唇收紧系数，用于压缩高口型。
+- 页面会将最新参数写入浏览器 `localStorage`，刷新后自动恢复。
+- 导出 JSON：点击“导出 JSON”生成当前参数文本，可继续使用“复制 JSON”或“下载 JSON”保留文件。
+- 从 JSON 粘贴导入：将外部预设粘贴到文本框中后点击按钮即可恢复参数。
+- 若页面检测到 `<stick-bot>` 组件，会调用 `setExpressionOverride(preset)`；否则使用内置火柴人预览演示实时效果。
 

--- a/web/js/tuner.js
+++ b/web/js/tuner.js
@@ -1,0 +1,321 @@
+import { PARAM_DEFINITIONS, TunerModel, createDownloadBlob } from './tuner.model.js';
+import { BigMouthAvatar } from './avatar.js';
+
+const statusEl = /** @type {HTMLDivElement} */ (document.getElementById('status'));
+const paramListEl = document.getElementById('param-list');
+const jsonTextarea = /** @type {HTMLTextAreaElement} */ (document.getElementById('preset-json'));
+const exportBtn = /** @type {HTMLButtonElement} */ (document.getElementById('export-btn'));
+const importBtn = /** @type {HTMLButtonElement} */ (document.getElementById('import-btn'));
+const copyBtn = /** @type {HTMLButtonElement} */ (document.getElementById('copy-btn'));
+const downloadBtn = /** @type {HTMLButtonElement} */ (document.getElementById('download-btn'));
+const avatarCanvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById('avatar-preview'));
+const curveCanvas = /** @type {HTMLCanvasElement | null} */ (document.getElementById('curve-canvas'));
+
+const model = new TunerModel();
+
+/** @type {Map<string, { slider: HTMLInputElement; number: HTMLInputElement }>} */
+const inputRefs = new Map();
+
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+
+const hostStickBot = document.querySelector('stick-bot');
+let localAvatar = null;
+let previewLoop = null;
+
+const ensureAvatar = () => {
+  if (!avatarCanvas) return null;
+  if (localAvatar) return localAvatar;
+  localAvatar = new BigMouthAvatar(avatarCanvas, { mouthSmoothing: 0.18 });
+  localAvatar.start();
+  return localAvatar;
+};
+
+const sampleBaseWave = (timeSeconds) => {
+  const phrases = [
+    { start: 0, duration: 0.7, frequency: 1.1, strength: 1 },
+    { start: 0.65, duration: 0.6, frequency: 1.6, strength: 0.75 },
+    { start: 1.35, duration: 0.8, frequency: 1.2, strength: 0.9 },
+    { start: 2.1, duration: 0.9, frequency: 1.8, strength: 0.95 },
+  ];
+  let value = 0;
+  for (const phrase of phrases) {
+    if (timeSeconds < phrase.start || timeSeconds > phrase.start + phrase.duration) {
+      continue;
+    }
+    const local = (timeSeconds - phrase.start) / phrase.duration;
+    const envelope = Math.sin(Math.PI * clamp01(local));
+    const wave = Math.abs(Math.sin(Math.PI * (timeSeconds - phrase.start) * phrase.frequency));
+    value = Math.max(value, envelope * wave * phrase.strength);
+  }
+  return value;
+};
+
+const applyExpressionModifiers = (base, params) => {
+  let value = base * (params.mouthOpenScale ?? 1);
+  value += (params.cornerCurve ?? 0) * 0.05;
+  value *= 1 + (params.lipTension ?? 0) * 0.15;
+  if ((params.eyeBlinkBias ?? 0) > 0.3) {
+    value *= 0.95 - Math.min(params.eyeBlinkBias, 0.6) * 0.2;
+  }
+  if (params.roundLipCompress ?? 0) {
+    const compress = clamp01(params.roundLipCompress);
+    const exponent = 1 + compress * 1.6;
+    value = Math.pow(clamp01(value), exponent);
+  }
+  return clamp01(value);
+};
+
+const generateTimeline = (params) => {
+  const tickHz = Math.max(10, Math.min(120, Math.round(params.tickHz ?? 60)));
+  const alpha = Math.min(0.98, Math.max(0.02, params.emaAlpha ?? 0.24));
+  const duration = 3.6; // seconds
+  const step = 1 / tickHz;
+  const raw = [];
+  const smooth = [];
+  let ema = 0;
+  for (let t = 0, i = 0; t <= duration + 1e-6; t += step, i += 1) {
+    const base = sampleBaseWave(t % duration);
+    const modified = applyExpressionModifiers(base, params);
+    const viseme = Math.round(clamp01(modified) * 9);
+    raw.push({ t, v: modified, viseme });
+    if (i === 0) {
+      ema = modified;
+    } else {
+      ema = ema + alpha * (modified - ema);
+    }
+    smooth.push({ t, v: ema, viseme: Math.round(clamp01(ema) * 9) });
+  }
+  return { raw, smooth, duration, tickHz };
+};
+
+class LocalTimelinePreview {
+  constructor(avatar, canvas) {
+    this.avatar = avatar;
+    this.canvas = canvas;
+    this.timeline = generateTimeline(model.getState());
+    this.startTime = performance.now();
+    this.rafId = null;
+    this.drawCurves();
+    this.loop = this.loop.bind(this);
+    this.start();
+  }
+
+  setParams(params) {
+    this.timeline = generateTimeline(params);
+    this.drawCurves();
+  }
+
+  start() {
+    if (this.rafId !== null) return;
+    this.startTime = performance.now();
+    this.rafId = requestAnimationFrame(this.loop);
+  }
+
+  stop() {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  loop(timestamp) {
+    if (!this.avatar || !this.timeline) {
+      this.rafId = requestAnimationFrame(this.loop);
+      return;
+    }
+    const elapsed = (timestamp - this.startTime) / 1000;
+    const duration = this.timeline.duration || 1;
+    const tickHz = this.timeline.tickHz || 60;
+    const time = elapsed % duration;
+    const index = Math.min(this.timeline.smooth.length - 1, Math.floor(time * tickHz));
+    const frame = this.timeline.smooth[index];
+    if (frame) {
+      this.avatar.setMouthFrame({ value: frame.v, visemeId: frame.viseme ?? 0, phoneme: 'preview' });
+    }
+    this.rafId = requestAnimationFrame(this.loop);
+  }
+
+  drawCurves() {
+    if (!this.canvas || !this.timeline) return;
+    const ctx = this.canvas.getContext('2d');
+    if (!ctx) return;
+    const { width, height } = this.canvas;
+    ctx.clearRect(0, 0, width, height);
+
+    const padding = 20;
+    const innerWidth = width - padding * 2;
+    const innerHeight = height - padding * 2;
+
+    const drawCurve = (points, color) => {
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      points.forEach((point, idx) => {
+        const x = padding + (point.t / this.timeline.duration) * innerWidth;
+        const y = padding + (1 - point.v) * innerHeight;
+        if (idx === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+      });
+      ctx.stroke();
+    };
+
+    ctx.strokeStyle = 'rgba(148, 163, 184, 0.6)';
+    ctx.lineWidth = 1;
+    ctx.setLineDash([4, 4]);
+    for (let i = 0; i <= 4; i += 1) {
+      const y = padding + (innerHeight / 4) * i;
+      ctx.beginPath();
+      ctx.moveTo(padding, y);
+      ctx.lineTo(padding + innerWidth, y);
+      ctx.stroke();
+    }
+    ctx.setLineDash([]);
+
+    drawCurve(this.timeline.raw, '#6366f1');
+    drawCurve(this.timeline.smooth, '#f97316');
+  }
+}
+
+const initParamInputs = () => {
+  if (!paramListEl) return;
+  paramListEl.innerHTML = '';
+  for (const definition of PARAM_DEFINITIONS) {
+    const item = document.createElement('div');
+    item.className = 'param-item';
+
+    const label = document.createElement('label');
+    label.textContent = `${definition.label}`;
+    label.title = definition.description;
+    item.appendChild(label);
+
+    const controls = document.createElement('div');
+    controls.className = 'param-controls';
+
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = String(definition.min);
+    slider.max = String(definition.max);
+    slider.step = String(definition.step);
+    slider.value = String(model.getState()[definition.key]);
+    controls.appendChild(slider);
+
+    const numberInput = document.createElement('input');
+    numberInput.type = 'number';
+    numberInput.min = String(definition.min);
+    numberInput.max = String(definition.max);
+    numberInput.step = String(definition.step);
+    numberInput.value = String(model.getState()[definition.key]);
+    controls.appendChild(numberInput);
+
+    item.appendChild(controls);
+    paramListEl.appendChild(item);
+
+    slider.addEventListener('input', () => {
+      numberInput.value = slider.value;
+      model.update(definition.key, slider.value);
+    });
+    numberInput.addEventListener('change', () => {
+      slider.value = numberInput.value;
+      model.update(definition.key, numberInput.value);
+    });
+    inputRefs.set(definition.key, { slider, number: numberInput });
+  }
+};
+
+const updateInputs = (state) => {
+  for (const [key, refs] of inputRefs.entries()) {
+    const value = state[key];
+    if (refs.slider.value !== String(value)) {
+      refs.slider.value = String(value);
+    }
+    if (refs.number.value !== String(value)) {
+      refs.number.value = String(value);
+    }
+  }
+};
+
+const applyPreset = (preset) => {
+  if (hostStickBot && typeof hostStickBot.setExpressionOverride === 'function') {
+    hostStickBot.setExpressionOverride(preset);
+  }
+  if (!previewLoop) {
+    const avatar = ensureAvatar();
+    if (avatar) {
+      previewLoop = new LocalTimelinePreview(avatar, curveCanvas);
+    }
+  }
+  if (previewLoop) {
+    previewLoop.setParams(preset);
+  }
+};
+
+const setStatus = (message) => {
+  if (statusEl) {
+    statusEl.textContent = message;
+  }
+};
+
+exportBtn?.addEventListener('click', () => {
+  const preset = model.toJSON();
+  const json = JSON.stringify(preset, null, 2);
+  jsonTextarea.value = json;
+  setStatus('已生成 JSON，可复制或下载。');
+});
+
+copyBtn?.addEventListener('click', async () => {
+  const text = jsonTextarea.value.trim() || JSON.stringify(model.toJSON(), null, 2);
+  try {
+    if (navigator.clipboard && text) {
+      await navigator.clipboard.writeText(text);
+      setStatus('JSON 已复制到剪贴板。');
+    } else {
+      setStatus('浏览器不支持剪贴板 API，请手动复制。');
+    }
+  } catch (error) {
+    console.warn('[tuner] 复制失败', error);
+    setStatus('复制失败，请检查浏览器权限。');
+  }
+});
+
+downloadBtn?.addEventListener('click', () => {
+  const text = jsonTextarea.value.trim() || JSON.stringify(model.toJSON(), null, 2);
+  const blob = createDownloadBlob(text);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'stickbot-tuner.json';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  setStatus('已下载 JSON 文件。');
+});
+
+importBtn?.addEventListener('click', () => {
+  const text = jsonTextarea.value.trim();
+  if (!text) {
+    setStatus('请先粘贴 JSON 文本。');
+    return;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    model.replaceAll(parsed);
+    setStatus('已从 JSON 导入并更新参数。');
+  } catch (error) {
+    console.error('[tuner] 导入失败：', error);
+    setStatus('导入失败，请确认 JSON 格式正确。');
+  }
+});
+
+model.subscribe((state) => {
+  updateInputs(state);
+  applyPreset(state);
+});
+
+initParamInputs();
+applyPreset(model.getState());
+setStatus('参数已就绪，调整后自动保存到浏览器。');
+

--- a/web/js/tuner.model.js
+++ b/web/js/tuner.model.js
@@ -1,0 +1,198 @@
+const STORAGE_KEY = 'stickbot:tuner:preset';
+
+/**
+ * 参数元数据，用于生成 UI 与限定取值范围。
+ */
+export const PARAM_DEFINITIONS = [
+  {
+    key: 'mouthOpenScale',
+    label: 'mouthOpenScale',
+    min: 0.4,
+    max: 2,
+    step: 0.01,
+    defaultValue: 1,
+    description: '嘴巴张开倍数，用于放大/缩小整体口型幅度。',
+  },
+  {
+    key: 'lipTension',
+    label: 'lipTension',
+    min: 0,
+    max: 1,
+    step: 0.01,
+    defaultValue: 0.2,
+    description: '嘴唇收紧程度，越大越紧绷。',
+  },
+  {
+    key: 'cornerCurve',
+    label: 'cornerCurve',
+    min: -1,
+    max: 1,
+    step: 0.01,
+    defaultValue: 0.1,
+    description: '嘴角弯曲程度，正值上扬，负值下压。',
+  },
+  {
+    key: 'eyeBlinkBias',
+    label: 'eyeBlinkBias',
+    min: -0.6,
+    max: 0.6,
+    step: 0.01,
+    defaultValue: 0,
+    description: '眨眼偏置，影响 blink 节奏。',
+  },
+  {
+    key: 'headNodAmp',
+    label: 'headNodAmp',
+    min: 0,
+    max: 1,
+    step: 0.01,
+    defaultValue: 0.15,
+    description: '点头幅度，越大越明显。',
+  },
+  {
+    key: 'swayAmp',
+    label: 'swayAmp',
+    min: 0,
+    max: 0.8,
+    step: 0.01,
+    defaultValue: 0.18,
+    description: '身体左右摆动幅度。',
+  },
+  {
+    key: 'emaAlpha',
+    label: 'emaAlpha',
+    min: 0.02,
+    max: 0.6,
+    step: 0.01,
+    defaultValue: 0.24,
+    description: '口型平滑系数（指数滑动平均 alpha）。',
+  },
+  {
+    key: 'tickHz',
+    label: 'tickHz',
+    min: 10,
+    max: 120,
+    step: 1,
+    defaultValue: 60,
+    description: '时间轴刷新频率（Hz）。',
+  },
+  {
+    key: 'roundLipCompress',
+    label: 'roundLipCompress',
+    min: 0,
+    max: 0.9,
+    step: 0.01,
+    defaultValue: 0.32,
+    description: '圆唇收紧强度，用于压缩高口型。',
+  },
+];
+
+const DEFAULT_STATE = PARAM_DEFINITIONS.reduce((acc, item) => {
+  acc[item.key] = item.defaultValue;
+  return acc;
+}, {});
+
+const clampValue = (value, definition) => {
+  if (Number.isNaN(value)) {
+    return definition.defaultValue;
+  }
+  const min = definition.min;
+  const max = definition.max;
+  const clamped = Math.min(max, Math.max(min, value));
+  const fixed = Math.round(clamped / definition.step) * definition.step;
+  return Number.parseFloat(fixed.toFixed(4));
+};
+
+const safeParse = (text) => {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return null;
+  }
+};
+
+/**
+ * 管理调参状态与本地持久化。
+ */
+export class TunerModel {
+  constructor(storage = window.localStorage) {
+    this.storage = storage;
+    this.subscribers = new Set();
+    this.state = { ...DEFAULT_STATE };
+    this.loadFromStorage();
+  }
+
+  loadFromStorage() {
+    if (!this.storage) return;
+    try {
+      const raw = this.storage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = safeParse(raw);
+      if (!parsed || typeof parsed !== 'object') return;
+      this.state = this.normalizeState(parsed);
+    } catch (error) {
+      console.warn('[tuner] 读取本地参数失败，将使用默认值。', error);
+    }
+  }
+
+  saveToStorage() {
+    if (!this.storage) return;
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(this.state));
+    } catch (error) {
+      console.warn('[tuner] 保存参数到本地失败。', error);
+    }
+  }
+
+  normalizeState(patch = {}) {
+    const nextState = { ...DEFAULT_STATE };
+    for (const def of PARAM_DEFINITIONS) {
+      const value = Number.parseFloat(patch[def.key]);
+      nextState[def.key] = clampValue(value, def);
+    }
+    return nextState;
+  }
+
+  getState() {
+    return { ...this.state };
+  }
+
+  subscribe(callback) {
+    this.subscribers.add(callback);
+    callback(this.getState());
+    return () => this.subscribers.delete(callback);
+  }
+
+  notify() {
+    const snapshot = this.getState();
+    for (const listener of this.subscribers) {
+      listener(snapshot);
+    }
+  }
+
+  update(key, rawValue) {
+    const definition = PARAM_DEFINITIONS.find((item) => item.key === key);
+    if (!definition) return;
+    const numericValue = Number.parseFloat(rawValue);
+    const next = clampValue(numericValue, definition);
+    if (this.state[key] === next) return;
+    this.state = { ...this.state, [key]: next };
+    this.saveToStorage();
+    this.notify();
+  }
+
+  replaceAll(preset) {
+    this.state = this.normalizeState(preset);
+    this.saveToStorage();
+    this.notify();
+  }
+
+  toJSON() {
+    return this.getState();
+  }
+}
+
+export const createDownloadBlob = (text) => {
+  return new Blob([text], { type: 'application/json' });
+};
+

--- a/web/tuner.html
+++ b/web/tuner.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>stickbot 参数 Tuner</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+        background: #f4f4f7;
+        color: #111827;
+      }
+
+      main {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 24px;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+
+      .preview-column {
+        flex: 1 1 480px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        align-items: stretch;
+      }
+
+      .preview-card {
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      canvas {
+        width: 100%;
+        border-radius: 12px;
+        background: #fff;
+      }
+
+      #avatar-preview {
+        max-width: 480px;
+        align-self: center;
+        box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.14);
+      }
+
+      #curve-canvas {
+        height: 160px;
+        box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.2);
+      }
+
+      .legend {
+        display: flex;
+        gap: 24px;
+        flex-wrap: wrap;
+        font-size: 13px;
+        color: #4b5563;
+      }
+
+      .legend span::before {
+        content: '';
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border-radius: 999px;
+        margin-right: 6px;
+        vertical-align: middle;
+      }
+
+      .legend span.raw::before {
+        background: #6366f1;
+      }
+
+      .legend span.smooth::before {
+        background: #f97316;
+      }
+
+      aside.panel {
+        width: 360px;
+        min-width: 320px;
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 18px 38px rgba(15, 23, 42, 0.1);
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 24px;
+      }
+
+      .param-list {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .param-item {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .param-item label {
+        font-size: 14px;
+        font-weight: 600;
+        color: #1f2937;
+      }
+
+      .param-controls {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .param-controls input[type='range'] {
+        flex: 1;
+      }
+
+      .param-controls input[type='number'] {
+        width: 86px;
+        padding: 6px 8px;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        font-size: 14px;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 120px;
+        padding: 12px;
+        border-radius: 12px;
+        border: 1px solid #d1d5db;
+        font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+        font-size: 13px;
+        resize: vertical;
+        box-sizing: border-box;
+      }
+
+      .button-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 10px 18px;
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        background: #e5e7eb;
+        color: #1f2937;
+        transition: transform 0.08s ease, box-shadow 0.12s ease;
+      }
+
+      button.primary {
+        background: linear-gradient(135deg, #6366f1, #8b5cf6);
+        color: #fff;
+        box-shadow: 0 10px 20px rgba(99, 102, 241, 0.28);
+      }
+
+      button:active {
+        transform: translateY(1px) scale(0.99);
+        box-shadow: none;
+      }
+
+      .status {
+        font-size: 13px;
+        color: #6b7280;
+      }
+
+      @media (max-width: 960px) {
+        aside.panel {
+          width: 100%;
+        }
+        main {
+          flex-direction: column;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="preview-column">
+        <div class="preview-card">
+          <canvas id="avatar-preview" width="420" height="420"></canvas>
+          <div class="legend">
+            <span class="raw">原始 mouthTimeline</span>
+            <span class="smooth">平滑后 mouth</span>
+          </div>
+        </div>
+        <div class="preview-card">
+          <canvas id="curve-canvas" width="420" height="200"></canvas>
+          <p style="margin: 0; font-size: 13px; color: #4b5563;">
+            曲线叠加用于观察 EMA 平滑效果，可拖动右侧滑条实时更新。
+          </p>
+        </div>
+      </section>
+      <aside class="panel">
+        <div>
+          <h1>可视化调参面板 Tuner</h1>
+          <p style="margin: 8px 0 0; font-size: 14px; color: #4b5563;">
+            调整 stickbot 表情与平滑参数，导出 JSON 以供服务端或组件引用。
+          </p>
+        </div>
+        <div id="param-list" class="param-list"></div>
+        <div>
+          <label for="preset-json" style="display: block; font-weight: 600; margin-bottom: 8px;">导入 / 导出 JSON</label>
+          <textarea id="preset-json" placeholder="在此粘贴 JSON 后点击“从 JSON 粘贴导入”。"></textarea>
+          <div class="button-row" style="margin-top: 12px;">
+            <button id="export-btn" class="primary">导出 JSON</button>
+            <button id="copy-btn">复制 JSON</button>
+            <button id="download-btn">下载 JSON</button>
+            <button id="import-btn">从 JSON 粘贴导入</button>
+          </div>
+        </div>
+        <div class="status" id="status">参数将在本地浏览器保存，可随时恢复上次调参结果。</div>
+      </aside>
+    </main>
+    <script type="module" src="./js/tuner.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated tuner.html page with a canvas preview, curve overlay, and JSON import/export workflow
- introduce tuner.model.js to manage parameter state, validation, and localStorage persistence
- implement tuner.js to render controls, drive previews, and integrate with optional <stick-bot> hosts
- document the new tuner entry point and parameters in web/README.md

## Testing
- Manual verification of tuner.html in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc82af12dc8328bf627a24305f2afc