### PR TITLE
feat(player): add auto-gain and session preset memory for consistent mouth amplitude

### DIFF
--- a/weapp-stickbot/pages/index/index.wxml
+++ b/weapp-stickbot/pages/index/index.wxml
@@ -14,6 +14,10 @@
         <view class="picker-value">{{renderModes[renderModeIndex]}}</view>
       </picker>
     </view>
+    <view class="switch-row">
+      <text class="label">自动增益</text>
+      <switch checked="{{autoGainEnabled}}" bindchange="onAutoGainToggle"></switch>
+    </view>
     <view class="info">当前 mouth：{{mouthDisplay}}，viseme：{{visemeId}}</view>
     <view class="button-group">
       <button type="primary" bindtap="onSynthesize">开始合成</button>

--- a/weapp-stickbot/pages/index/index.wxss
+++ b/weapp-stickbot/pages/index/index.wxss
@@ -49,6 +49,13 @@
   color: #6b7280;
 }
 
+.switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+}
+
 .button-group {
   display: flex;
   gap: 12px;

--- a/weapp-stickbot/utils/auto-gain.js
+++ b/weapp-stickbot/utils/auto-gain.js
@@ -1,0 +1,125 @@
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const DEFAULT_AUTO_GAIN_CONFIG = {
+  windowSec: 5,
+  targetRMS: 0.5,
+  floor: 0.6,
+  ceil: 1.5,
+  smoothing: 0.3,
+  sampleStep: 1 / 60,
+};
+
+const toNumber = (value, fallback = 0) => {
+  const numeric = Number.parseFloat(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const sampleTimelineValue = (timeline, time) => {
+  if (!Array.isArray(timeline) || timeline.length === 0) {
+    return 0;
+  }
+  if (time <= timeline[0].t) {
+    return toNumber(timeline[0].v ?? timeline[0].value ?? 0);
+  }
+  for (let i = 1; i < timeline.length; i += 1) {
+    const prev = timeline[i - 1];
+    const next = timeline[i];
+    if (time <= next.t) {
+      const span = Math.max(next.t - prev.t, 1e-6);
+      const ratio = (time - prev.t) / span;
+      const prevValue = toNumber(prev.v ?? prev.value ?? 0);
+      const nextValue = toNumber(next.v ?? next.value ?? 0);
+      return prevValue + (nextValue - prevValue) * ratio;
+    }
+  }
+  const last = timeline[timeline.length - 1];
+  return toNumber(last.v ?? last.value ?? 0);
+};
+
+class AutoGainProcessor {
+  constructor(timeline, config = {}) {
+    this.config = { ...DEFAULT_AUTO_GAIN_CONFIG, ...config };
+    this.sampleStep = this.config.sampleStep || DEFAULT_AUTO_GAIN_CONFIG.sampleStep;
+    this.timeline = Array.isArray(timeline) ? timeline : [];
+    this.samples = [];
+    this.prefixSquares = [];
+    this.lastGain = 1;
+    this.lastTime = null;
+    this.buildSamples();
+  }
+
+  buildSamples() {
+    if (this.timeline.length === 0) {
+      this.samples = [0];
+      this.prefixSquares = [0, 0];
+      return;
+    }
+    const duration = this.timeline[this.timeline.length - 1].t ?? 0;
+    const window = Math.max(this.config.windowSec, 0.001);
+    const sampleCount = Math.max(2, Math.ceil((duration + window) / this.sampleStep) + 1);
+    this.samples = new Array(sampleCount);
+    for (let i = 0; i < sampleCount; i += 1) {
+      const t = i * this.sampleStep;
+      const value = clamp(sampleTimelineValue(this.timeline, t), 0, 1);
+      this.samples[i] = value;
+    }
+    this.prefixSquares = new Array(sampleCount + 1).fill(0);
+    for (let i = 0; i < sampleCount; i += 1) {
+      const value = this.samples[i];
+      this.prefixSquares[i + 1] = this.prefixSquares[i] + value * value;
+    }
+  }
+
+  reset() {
+    this.lastGain = 1;
+    this.lastTime = null;
+  }
+
+  setTimeline(timeline) {
+    this.timeline = Array.isArray(timeline) ? timeline : [];
+    this.buildSamples();
+    this.reset();
+  }
+
+  getGain(time) {
+    if (!Number.isFinite(time) || time <= 0) {
+      this.lastGain = 1;
+      this.lastTime = time;
+      return 1;
+    }
+    if (this.lastTime !== null && time < this.lastTime) {
+      this.lastGain = 1;
+    }
+    this.lastTime = time;
+    const windowSamples = Math.max(1, Math.round(this.config.windowSec / this.sampleStep));
+    const currentIndex = clamp(Math.floor(time / this.sampleStep), 0, this.samples.length - 1);
+    const startIndex = Math.max(0, currentIndex - windowSamples + 1);
+    const sumSquares = this.prefixSquares[currentIndex + 1] - this.prefixSquares[startIndex];
+    const count = currentIndex + 1 - startIndex;
+    if (count <= 0) {
+      this.lastGain = 1;
+      return 1;
+    }
+    const rms = Math.sqrt(sumSquares / count);
+    if (!Number.isFinite(rms) || rms < 1e-4) {
+      this.lastGain = 1;
+      return 1;
+    }
+    const rawGain = clamp(this.config.targetRMS / rms, this.config.floor, this.config.ceil);
+    const smoothing = clamp(this.config.smoothing ?? 0, 0, 0.95);
+    const next = smoothing > 0 ? this.lastGain + (rawGain - this.lastGain) * smoothing : rawGain;
+    this.lastGain = clamp(next, this.config.floor, this.config.ceil);
+    return this.lastGain;
+  }
+
+  apply(time, value) {
+    const gain = this.getGain(time);
+    const scaled = clamp((value ?? 0) * gain, 0, 1);
+    return { value: scaled, gain };
+  }
+}
+
+module.exports = {
+  AutoGainProcessor,
+  DEFAULT_AUTO_GAIN_CONFIG,
+};

--- a/web/index.html
+++ b/web/index.html
@@ -137,6 +137,10 @@
           <input type="checkbox" id="use-webspeech" checked />
           无时间轴时尝试使用浏览器 Web Speech API
         </label>
+        <label>
+          <input type="checkbox" id="auto-gain-toggle" checked />
+          自动增益口型幅度
+        </label>
         <div class="slider-group">
           <span>语速：<span id="rate-display">1.0</span></span>
           <input type="range" id="rate-slider" min="0.5" max="2" step="0.1" value="1" />

--- a/web/js/auto-gain.js
+++ b/web/js/auto-gain.js
@@ -1,0 +1,120 @@
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+export const DEFAULT_AUTO_GAIN_CONFIG = {
+  windowSec: 5,
+  targetRMS: 0.5,
+  floor: 0.6,
+  ceil: 1.5,
+  smoothing: 0.3,
+  sampleStep: 1 / 60,
+};
+
+const toNumber = (value, fallback = 0) => {
+  const numeric = Number.parseFloat(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const sampleTimelineValue = (timeline, time) => {
+  if (!Array.isArray(timeline) || timeline.length === 0) {
+    return 0;
+  }
+  if (time <= timeline[0].t) {
+    return toNumber(timeline[0].v ?? timeline[0].value ?? 0);
+  }
+  for (let i = 1; i < timeline.length; i += 1) {
+    const prev = timeline[i - 1];
+    const next = timeline[i];
+    if (time <= next.t) {
+      const span = Math.max(next.t - prev.t, 1e-6);
+      const ratio = (time - prev.t) / span;
+      const prevValue = toNumber(prev.v ?? prev.value ?? 0);
+      const nextValue = toNumber(next.v ?? next.value ?? 0);
+      return prevValue + (nextValue - prevValue) * ratio;
+    }
+  }
+  const last = timeline[timeline.length - 1];
+  return toNumber(last.v ?? last.value ?? 0);
+};
+
+export class AutoGainProcessor {
+  constructor(timeline, config = {}) {
+    this.timeline = Array.isArray(timeline) ? timeline : [];
+    this.config = { ...DEFAULT_AUTO_GAIN_CONFIG, ...config };
+    this.sampleStep = this.config.sampleStep || DEFAULT_AUTO_GAIN_CONFIG.sampleStep;
+    this.samples = [];
+    this.prefixSquares = [];
+    this.lastGain = 1;
+    this.lastTime = null;
+    this.buildSamples();
+  }
+
+  buildSamples() {
+    if (this.timeline.length === 0) {
+      this.samples = [0];
+      this.prefixSquares = [0, 0];
+      return;
+    }
+    const duration = this.timeline[this.timeline.length - 1].t ?? 0;
+    const window = Math.max(this.config.windowSec, 0.001);
+    const sampleCount = Math.max(2, Math.ceil((duration + window) / this.sampleStep) + 1);
+    this.samples = new Array(sampleCount);
+    for (let i = 0; i < sampleCount; i += 1) {
+      const t = i * this.sampleStep;
+      const value = clamp(sampleTimelineValue(this.timeline, t), 0, 1);
+      this.samples[i] = value;
+    }
+    this.prefixSquares = new Array(sampleCount + 1).fill(0);
+    for (let i = 0; i < sampleCount; i += 1) {
+      const value = this.samples[i];
+      this.prefixSquares[i + 1] = this.prefixSquares[i] + value * value;
+    }
+  }
+
+  reset() {
+    this.lastGain = 1;
+    this.lastTime = null;
+  }
+
+  setTimeline(timeline) {
+    this.timeline = Array.isArray(timeline) ? timeline : [];
+    this.buildSamples();
+    this.reset();
+  }
+
+  getGain(time) {
+    if (!Number.isFinite(time) || time <= 0) {
+      this.lastGain = 1;
+      this.lastTime = time;
+      return 1;
+    }
+    if (this.lastTime !== null && time < this.lastTime) {
+      this.lastGain = 1;
+    }
+    this.lastTime = time;
+    const windowSamples = Math.max(1, Math.round(this.config.windowSec / this.sampleStep));
+    const currentIndex = clamp(Math.floor(time / this.sampleStep), 0, this.samples.length - 1);
+    const startIndex = Math.max(0, currentIndex - windowSamples + 1);
+    const sumSquares = this.prefixSquares[currentIndex + 1] - this.prefixSquares[startIndex];
+    const count = currentIndex + 1 - startIndex;
+    if (count <= 0) {
+      this.lastGain = 1;
+      return 1;
+    }
+    const rms = Math.sqrt(sumSquares / count);
+    if (!Number.isFinite(rms) || rms < 1e-4) {
+      this.lastGain = 1;
+      return 1;
+    }
+    const rawGain = clamp(this.config.targetRMS / rms, this.config.floor, this.config.ceil);
+    const smoothing = clamp(this.config.smoothing ?? 0, 0, 0.95);
+    const next = smoothing > 0 ? this.lastGain + (rawGain - this.lastGain) * smoothing : rawGain;
+    this.lastGain = clamp(next, this.config.floor, this.config.ceil);
+    return this.lastGain;
+  }
+
+  apply(time, value) {
+    const gain = this.getGain(time);
+    const scaled = clamp((value ?? 0) * gain, 0, 1);
+    return { value: scaled, gain };
+  }
+}

--- a/web/tuner.html
+++ b/web/tuner.html
@@ -218,6 +218,10 @@
             调整 stickbot 表情与平滑参数，导出 JSON 以供服务端或组件引用。
           </p>
         </div>
+        <label style="display: flex; align-items: center; gap: 8px; font-size: 14px;">
+          <input type="checkbox" id="auto-gain-toggle" checked />
+          预览启用自动增益
+        </label>
         <div id="param-list" class="param-list"></div>
         <div>
           <label for="preset-json" style="display: block; font-weight: 600; margin-bottom: 8px;">导入 / 导出 JSON</label>


### PR DESCRIPTION
## Summary
- add auto-gain controls to the core TimelinePlayer and expose configurable defaults
- enable auto-gain toggles plus persisted preset memory across the web demo and tuner, using a shared processor
- add matching auto-gain storage and processing for the weapp player to stabilize mouth amplitude across sessions

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc8a56df148328ae62280b018af94c