### PR TITLE
feat(roles): add multi-role profiles, API endpoints and UI switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,35 @@ npm run dev
 
 逐词字幕还支持在网页面板粘贴 WebVTT 文本：勾选“使用手动 VTT”即可覆盖服务端结果，便于与外部字幕工具联调。若仅需字幕文本，可直接请求 `GET /tts/vtt`。
 
+## 角色档案
+
+第二轮开始引入 `/roles/*.json` 角色档案，结合表情预设与主题皮肤实现“一键换人格”：
+
+- 服务端会在启动时读取 `roles/` 目录，并暴露 `GET /roles` 与 `GET /roles/:id` 接口；
+- 网页端、微信小程序会拉取该列表，切换时同步更新 voice、渲染模式、主题配色与 `setExpressionOverride`；
+- 档案文件为纯文本 JSON，字段示例如下：
+
+```json
+{
+  "id": "energetic",
+  "name": "活力型",
+  "description": "高能量动作与暖色主题，适合主持、口播等需要感染力的场景。",
+  "voice": "zh",
+  "preset": {
+    "mouthOpenScale": 1.25,
+    "lipTension": -0.2,
+    "cornerCurve": 0.3,
+    "eyeBlinkBias": 0.15,
+    "headNodAmp": 0.6,
+    "swayAmp": 0.55
+  },
+  "theme": "bright",
+  "renderMode": "vector"
+}
+```
+
+可按需增加更多角色（至少保留一个 `default`），修改后无需重启前端即可生效。
+
 ## 架构概览
 
 ```

--- a/roles/default.json
+++ b/roles/default.json
@@ -1,0 +1,16 @@
+{
+  "id": "default",
+  "name": "基础款",
+  "description": "默认表情与经典紫色主题，适合展示 stickbot 的基础形象。",
+  "voice": "zh",
+  "preset": {
+    "mouthOpenScale": 1.0,
+    "lipTension": 0,
+    "cornerCurve": 0.05,
+    "eyeBlinkBias": 0,
+    "headNodAmp": 0.2,
+    "swayAmp": 0.25
+  },
+  "theme": "classic",
+  "renderMode": "vector"
+}

--- a/roles/energetic.json
+++ b/roles/energetic.json
@@ -1,0 +1,16 @@
+{
+  "id": "energetic",
+  "name": "活力型",
+  "description": "高能量动作与暖色主题，适合主持、口播等需要感染力的场景。",
+  "voice": "zh",
+  "preset": {
+    "mouthOpenScale": 1.25,
+    "lipTension": -0.2,
+    "cornerCurve": 0.3,
+    "eyeBlinkBias": 0.15,
+    "headNodAmp": 0.6,
+    "swayAmp": 0.55
+  },
+  "theme": "bright",
+  "renderMode": "vector"
+}

--- a/roles/soft.json
+++ b/roles/soft.json
@@ -1,0 +1,16 @@
+{
+  "id": "soft",
+  "name": "轻柔型",
+  "description": "嘴角更放松、眨眼更频繁，并配合柔和的浅色主题，适合阅读与陪伴类场景。",
+  "voice": "en-US",
+  "preset": {
+    "mouthOpenScale": 0.85,
+    "lipTension": 0.25,
+    "cornerCurve": -0.1,
+    "eyeBlinkBias": -0.2,
+    "headNodAmp": 0.15,
+    "swayAmp": 0.18
+  },
+  "theme": "pastel",
+  "renderMode": "vector"
+}

--- a/weapp-stickbot/README.md
+++ b/weapp-stickbot/README.md
@@ -12,6 +12,13 @@
 - `pages/index`：主页面，实现文本输入、TTS 调用与口型渲染。
 - `assets/`（可选）：用户可自行放置 `mouth/v0.png` 等贴图文件。
 
+## 角色档案切换
+
+- 首页顶部新增“角色档案”选择器，会请求服务端 `GET /roles` 获取 JSON 列表；
+- 选中角色后，默认 voice、渲染模式、主题配色以及表情预设会同时更新；
+- 当前选择会写入 `wx.setStorageSync('stickbot:role-profile')`，下次打开自动恢复；
+- 若服务端暂未提供档案，则回退到仓库内置的 `default/energetic/soft` 示例，可在 `roles/` 中自由增删。
+
 ## 使用步骤
 
 1. 在小程序管理后台添加合法域名（开发环境可勾选“开发阶段忽略”），确保包含 `http://localhost:8787` 或部署地址。

--- a/weapp-stickbot/pages/index/index.wxml
+++ b/weapp-stickbot/pages/index/index.wxml
@@ -1,7 +1,15 @@
-<view class="container">
-  <canvas type="2d" canvas-id="avatar" style="width: 320px; height: 420px; background: #ffffff; border-radius: 16px;"></canvas>
+<view class="container {{themeClass}}">
+  <canvas type="2d" canvas-id="avatar" class="avatar-canvas"></canvas>
   <view class="panel">
     <textarea class="text-input" value="{{text}}" placeholder="请输入要朗读的文本" bindinput="onTextInput"></textarea>
+    <view class="selector">
+      <text class="label">角色档案</text>
+      <picker mode="selector" range="{{roleNames}}" value="{{roleIndex}}" bindchange="onRoleChange">
+        <view class="picker-value">{{roleNames[roleIndex]}}</view>
+      </picker>
+      <text class="role-description">{{roleDescription}}</text>
+      <text class="role-meta">{{roleMeta}}</text>
+    </view>
     <view class="selector">
       <text class="label">TTS 供应器</text>
       <picker mode="selector" range="{{providers}}" value="{{providerIndex}}" bindchange="onProviderChange">

--- a/weapp-stickbot/pages/index/index.wxss
+++ b/weapp-stickbot/pages/index/index.wxss
@@ -4,6 +4,11 @@
   align-items: center;
   padding: 16px;
   gap: 16px;
+  min-height: 100vh;
+  width: 100%;
+  box-sizing: border-box;
+  background: #f5f5f5;
+  color: #1f2937;
 }
 
 .panel {
@@ -15,6 +20,7 @@
   flex-direction: column;
   gap: 12px;
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  color: #1f2937;
 }
 
 .text-input {
@@ -66,6 +72,24 @@
   color: #9ca3af;
 }
 
+.role-description {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.role-meta {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.avatar-canvas {
+  width: 320px;
+  height: 420px;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
 .subtitle-bar {
   width: 320px;
   min-height: 44px;
@@ -79,4 +103,106 @@
   font-size: 16px;
   letter-spacing: 0.5px;
   box-shadow: 0 16px 30px rgba(17, 24, 39, 0.18);
+}
+
+.container.theme-bright {
+  background: #fff7ed;
+  color: #7c2d12;
+}
+
+.container.theme-bright .panel {
+  background: #fffaf0;
+  color: #7c2d12;
+  box-shadow: 0 14px 32px rgba(249, 115, 22, 0.18);
+}
+
+.container.theme-bright .picker-value {
+  background: #fffbeb;
+  color: #9a3412;
+}
+
+.container.theme-bright .role-description,
+.container.theme-bright .role-meta,
+.container.theme-bright .info,
+.container.theme-bright .hint {
+  color: #b45309;
+}
+
+.container.theme-bright .avatar-canvas {
+  background: #fffaf0;
+  box-shadow: 0 14px 28px rgba(249, 115, 22, 0.16);
+}
+
+.container.theme-bright .subtitle-bar {
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: #fff7ed;
+  box-shadow: 0 16px 32px rgba(234, 88, 12, 0.22);
+}
+
+.container.theme-pastel {
+  background: #f3e8ff;
+  color: #4c1d95;
+}
+
+.container.theme-pastel .panel {
+  background: #fdf4ff;
+  color: #4c1d95;
+  box-shadow: 0 14px 30px rgba(147, 51, 234, 0.18);
+}
+
+.container.theme-pastel .picker-value {
+  background: #f8e8ff;
+  color: #6d28d9;
+}
+
+.container.theme-pastel .role-description,
+.container.theme-pastel .role-meta,
+.container.theme-pastel .info,
+.container.theme-pastel .hint {
+  color: #7c3aed;
+}
+
+.container.theme-pastel .avatar-canvas {
+  background: #fdf4ff;
+  box-shadow: 0 14px 28px rgba(147, 51, 234, 0.16);
+}
+
+.container.theme-pastel .subtitle-bar {
+  background: linear-gradient(135deg, #a855f7, #7c3aed);
+  color: #fdf4ff;
+  box-shadow: 0 16px 32px rgba(124, 58, 237, 0.22);
+}
+
+.container.theme-noir {
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.container.theme-noir .panel {
+  background: #1e293b;
+  color: #e2e8f0;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.6);
+}
+
+.container.theme-noir .picker-value {
+  background: #1f2937;
+  color: #bae6fd;
+}
+
+.container.theme-noir .role-description,
+.container.theme-noir .role-meta,
+.container.theme-noir .info,
+.container.theme-noir .hint {
+  color: #94a3b8;
+}
+
+.container.theme-noir .avatar-canvas {
+  background: #1e293b;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.6);
+}
+
+.container.theme-noir .subtitle-bar {
+  background: linear-gradient(135deg, #0ea5e9, #0369a1);
+  color: #0f172a;
+  box-shadow: 0 18px 38px rgba(14, 165, 233, 0.28);
 }

--- a/web/README.md
+++ b/web/README.md
@@ -14,6 +14,15 @@
 - **`js/lipsync.js`**：封装口型信号、时间轴插值与服务端请求，提供 `resolveServerUrl` 以跨源访问。
 - **`js/mouth-capture.js`**：实验性的摄像头口型捕捉器，若检测到全局 `faceMesh` 库则使用唇部关键点估计。
 
+## 角色档案与主题切换
+
+- 页面右侧“角色档案”下拉框会调用服务端 `GET /roles` 拉取 JSON 档案，切换后自动应用：
+  - `preset` 通过 `setExpressionOverride` 调整嘴角、眨眼与肢体幅度；
+  - `voice` 作为 `/tts` 的默认 `voice` 参数，同时覆盖 Web Speech 兜底语种；
+  - `renderMode` 与 `theme` 同步更新 Canvas 渲染模式与页面配色；
+- 档案存放于仓库根目录 `roles/`，可随时新增/修改，浏览器会在刷新后读取；
+- 浏览器会将最近一次选择保存在 `localStorage`，再次进入页面时自动恢复。
+
 ## 口型驱动优先级
 
 1. **服务端时间轴**：`/tts` 返回 `mouthTimeline` 时，`main.js` 会创建 `<audio>` 元素播放 `audioUrl`，同时调用 `MouthSignal.playTimeline`，以 ~80Hz 的关键帧驱动嘴唇开合。

--- a/web/index.html
+++ b/web/index.html
@@ -5,14 +5,37 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>stickbot 火柴人语音演示</title>
     <style>
-      /* 页面整体布局，左侧画布右侧控制面板 */
+      :root {
+        color-scheme: light dark;
+        --page-bg: #f5f5f5;
+        --page-text: #1f2937;
+        --card-bg: #ffffff;
+        --card-text: #1f2937;
+        --card-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+        --card-border: rgba(17, 24, 39, 0.08);
+        --accent-bg: #4f46e5;
+        --accent-text: #ffffff;
+        --secondary-bg: #e5e7eb;
+        --secondary-text: #1f2937;
+        --hint-text: #6b7280;
+        --timeline-bg: #f9fafb;
+        --timeline-border: #e5e7eb;
+        --input-border: #d1d5db;
+        --chip-bg: rgba(79, 70, 229, 0.08);
+        --chip-text: #4338ca;
+        --chip-active-bg: #4f46e5;
+        --chip-active-text: #ffffff;
+        --chip-active-shadow: 0 6px 16px rgba(79, 70, 229, 0.35);
+      }
+
       body {
         margin: 0;
         font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background: #f5f5f5;
-        color: #222;
+        background: var(--page-bg);
+        color: var(--page-text);
         display: flex;
         min-height: 100vh;
+        transition: background 0.3s ease, color 0.3s ease;
       }
 
       main {
@@ -24,20 +47,21 @@
       }
 
       canvas {
-        background: #fff;
+        background: var(--card-bg);
         border-radius: 12px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+        box-shadow: var(--card-shadow);
       }
 
       .controls {
         width: 320px;
-        background: #fff;
+        background: var(--card-bg);
         border-radius: 12px;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+        box-shadow: var(--card-shadow);
         padding: 20px;
         display: flex;
         flex-direction: column;
         gap: 16px;
+        color: var(--card-text);
       }
 
       textarea {
@@ -45,9 +69,11 @@
         height: 160px;
         padding: 12px;
         font-size: 14px;
-        border: 1px solid #ccc;
+        border: 1px solid var(--input-border);
         border-radius: 8px;
         resize: vertical;
+        background: var(--card-bg);
+        color: var(--card-text);
       }
 
       label {
@@ -55,6 +81,7 @@
         align-items: center;
         gap: 8px;
         font-size: 14px;
+        color: var(--card-text);
       }
 
       button {
@@ -67,13 +94,13 @@
       }
 
       button.primary {
-        background: #4f46e5;
-        color: #fff;
+        background: var(--accent-bg);
+        color: var(--accent-text);
       }
 
       button.secondary {
-        background: #e5e7eb;
-        color: #1f2937;
+        background: var(--secondary-bg);
+        color: var(--secondary-text);
       }
 
       button:active {
@@ -92,9 +119,30 @@
         gap: 6px;
       }
 
+      .selector-group select {
+        padding: 10px 12px;
+        border-radius: 8px;
+        border: 1px solid var(--input-border);
+        background: var(--card-bg);
+        color: var(--card-text);
+      }
+
+      .role-description {
+        margin: 0;
+        font-size: 13px;
+        color: var(--hint-text);
+        line-height: 1.4;
+      }
+
+      .role-meta {
+        margin: 0;
+        font-size: 12px;
+        color: var(--hint-text);
+      }
+
       .word-timeline {
-        border: 1px solid #e5e7eb;
-        background: #f9fafb;
+        border: 1px solid var(--timeline-border);
+        background: var(--timeline-bg);
         border-radius: 10px;
         padding: 12px;
         display: flex;
@@ -107,7 +155,7 @@
         align-items: center;
         justify-content: space-between;
         font-size: 13px;
-        color: #111827;
+        color: var(--card-text);
       }
 
       .word-timeline-header label {
@@ -115,7 +163,7 @@
         align-items: center;
         gap: 6px;
         font-size: 12px;
-        color: #4b5563;
+        color: var(--hint-text);
       }
 
       .word-timeline-bar {
@@ -124,24 +172,24 @@
         flex-wrap: wrap;
         gap: 6px;
         padding: 8px;
-        background: #ffffff;
+        background: var(--card-bg);
         border-radius: 8px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--timeline-border);
       }
 
       .word-chip {
         padding: 4px 6px;
         border-radius: 6px;
-        background: rgba(79, 70, 229, 0.08);
-        color: #4338ca;
+        background: var(--chip-bg);
+        color: var(--chip-text);
         font-size: 13px;
         transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
       }
 
       .word-chip.active {
-        background: #4f46e5;
-        color: #ffffff;
-        box-shadow: 0 6px 16px rgba(79, 70, 229, 0.35);
+        background: var(--chip-active-bg);
+        color: var(--chip-active-text);
+        box-shadow: var(--chip-active-shadow);
       }
 
       .word-timeline textarea {
@@ -149,11 +197,13 @@
         height: 96px;
         resize: vertical;
         border-radius: 8px;
-        border: 1px solid #d1d5db;
+        border: 1px solid var(--input-border);
         padding: 8px;
         font-size: 13px;
         font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
         box-sizing: border-box;
+        background: var(--card-bg);
+        color: var(--card-text);
       }
 
       .word-timeline-actions {
@@ -164,7 +214,7 @@
 
       .word-timeline-status {
         font-size: 12px;
-        color: #6b7280;
+        color: var(--hint-text);
       }
 
       .progress-container {
@@ -183,16 +233,110 @@
         bottom: 12px;
         right: 24px;
         font-size: 12px;
-        color: #666;
+        color: var(--hint-text);
+      }
+
+      body.theme-classic {
+        --page-bg: #f5f5f5;
+        --page-text: #1f2937;
+        --card-bg: #ffffff;
+        --card-text: #1f2937;
+        --card-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+        --card-border: rgba(17, 24, 39, 0.08);
+        --accent-bg: #4f46e5;
+        --accent-text: #ffffff;
+        --secondary-bg: #e5e7eb;
+        --secondary-text: #1f2937;
+        --hint-text: #6b7280;
+        --timeline-bg: #f9fafb;
+        --timeline-border: #e5e7eb;
+        --input-border: #d1d5db;
+        --chip-bg: rgba(79, 70, 229, 0.08);
+        --chip-text: #4338ca;
+        --chip-active-bg: #4f46e5;
+        --chip-active-text: #ffffff;
+        --chip-active-shadow: 0 6px 16px rgba(79, 70, 229, 0.35);
+      }
+
+      body.theme-bright {
+        --page-bg: #fff7ed;
+        --page-text: #7c2d12;
+        --card-bg: #fffaf0;
+        --card-text: #7c2d12;
+        --card-shadow: 0 12px 36px rgba(124, 45, 18, 0.1);
+        --card-border: rgba(249, 115, 22, 0.18);
+        --accent-bg: #f97316;
+        --accent-text: #ffffff;
+        --secondary-bg: #fed7aa;
+        --secondary-text: #7c2d12;
+        --hint-text: #b45309;
+        --timeline-bg: #fffbeb;
+        --timeline-border: rgba(251, 191, 36, 0.45);
+        --input-border: rgba(251, 146, 60, 0.45);
+        --chip-bg: rgba(249, 115, 22, 0.12);
+        --chip-text: #c2410c;
+        --chip-active-bg: #ea580c;
+        --chip-active-text: #fff7ed;
+        --chip-active-shadow: 0 6px 16px rgba(234, 88, 12, 0.28);
+      }
+
+      body.theme-noir {
+        --page-bg: #0f172a;
+        --page-text: #e2e8f0;
+        --card-bg: #1e293b;
+        --card-text: #e2e8f0;
+        --card-shadow: 0 18px 40px rgba(15, 23, 42, 0.65);
+        --card-border: rgba(148, 163, 184, 0.22);
+        --accent-bg: #38bdf8;
+        --accent-text: #0f172a;
+        --secondary-bg: #334155;
+        --secondary-text: #e2e8f0;
+        --hint-text: #94a3b8;
+        --timeline-bg: rgba(30, 41, 59, 0.9);
+        --timeline-border: rgba(148, 163, 184, 0.35);
+        --input-border: rgba(148, 163, 184, 0.45);
+        --chip-bg: rgba(56, 189, 248, 0.14);
+        --chip-text: #bae6fd;
+        --chip-active-bg: #0ea5e9;
+        --chip-active-text: #0f172a;
+        --chip-active-shadow: 0 8px 22px rgba(14, 165, 233, 0.38);
+      }
+
+      body.theme-pastel {
+        --page-bg: #f3e8ff;
+        --page-text: #4c1d95;
+        --card-bg: #fdf4ff;
+        --card-text: #4c1d95;
+        --card-shadow: 0 12px 32px rgba(76, 29, 149, 0.12);
+        --card-border: rgba(192, 132, 252, 0.35);
+        --accent-bg: #a855f7;
+        --accent-text: #fdf4ff;
+        --secondary-bg: #e9d5ff;
+        --secondary-text: #4c1d95;
+        --hint-text: #7c3aed;
+        --timeline-bg: rgba(253, 244, 255, 0.88);
+        --timeline-border: rgba(192, 132, 252, 0.4);
+        --input-border: rgba(167, 85, 247, 0.4);
+        --chip-bg: rgba(167, 85, 247, 0.14);
+        --chip-text: #6d28d9;
+        --chip-active-bg: #9333ea;
+        --chip-active-text: #fdf4ff;
+        --chip-active-shadow: 0 6px 18px rgba(147, 51, 234, 0.32);
       }
     </style>
   </head>
-  <body>
+  <body class="theme-classic">
     <main>
       <canvas id="stickbot-canvas" width="480" height="480"></canvas>
       <section class="controls">
         <h1 style="margin: 0">stickbot 控制面板</h1>
         <textarea id="speech-text" placeholder="请输入要朗读的文本">你好，我是 stickbot。今天我们一起练习口型同步！</textarea>
+        <div class="selector-group">
+          <label for="role-select">角色档案</label>
+          <select id="role-select"></select>
+          <p class="role-description" id="role-description">选择不同角色，stickbot 将切换 voice、表情预设与主题皮肤。</p>
+          <p class="role-meta" id="role-meta"></p>
+        </div>
         <div class="selector-group">
           <label for="tts-provider">TTS 供应器</label>
           <select id="tts-provider">


### PR DESCRIPTION
## Summary
- add role profile loading with caching and expose GET /roles endpoints
- provide sample role JSON definitions consumed by web and mini-app clients
- integrate role selector UI, theme switching, and preset expression handling across web and weapp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9640118883289c91feee9e29b189