### PR TITLE
perf(tts): add cache, concurrency de-dup and client prefetch with mild latency compensation

### DIFF
--- a/server/src/config.js
+++ b/server/src/config.js
@@ -63,6 +63,8 @@ export const loadServerConfig = async () => {
   const maxTextLen = Number(process.env.MAX_TEXT_LEN || 5000);
   const rateLimitRps = Number(process.env.RATE_LIMIT_RPS || 5);
   const maxConcurrency = Number(process.env.MAX_CONCURRENCY || 2);
+  const cacheMaxEntries = Number(process.env.TTS_CACHE_MAX_ENTRIES || 1000);
+  const cacheTtlMs = Number(process.env.TTS_CACHE_TTL_MS || 60 * 60 * 1000);
 
   /**
    * 若设置了自定义 viseme 映射文件，则尝试解析；
@@ -96,6 +98,10 @@ export const loadServerConfig = async () => {
       maxTextLen: Number.isFinite(maxTextLen) && maxTextLen > 0 ? maxTextLen : 5000,
       rateLimitRps: Number.isFinite(rateLimitRps) && rateLimitRps > 0 ? rateLimitRps : 5,
       maxConcurrency: Number.isFinite(maxConcurrency) && maxConcurrency > 0 ? maxConcurrency : 2,
+    },
+    cache: {
+      maxEntries: Number.isFinite(cacheMaxEntries) && cacheMaxEntries > 0 ? cacheMaxEntries : 1000,
+      ttlMs: Number.isFinite(cacheTtlMs) && cacheTtlMs > 0 ? cacheTtlMs : 60 * 60 * 1000,
     },
     logDir,
   };

--- a/web/js/lipsync.js
+++ b/web/js/lipsync.js
@@ -429,7 +429,7 @@ export const speakWithWebSpeech = (utterance, signal) => {
 /**
  * 请求服务端 `/tts` 接口，返回 JSON 结果。
  * @param {string} text - 合成文本。
- * @param {{ voice?: string, rate?: number, provider?: string, abortSignal?: AbortSignal }} options - 请求参数。
+ * @param {{ voice?: string, rate?: number, provider?: string, abortSignal?: AbortSignal, segmentIndex?: number, segmentCount?: number, segmentId?: string }} options - 请求参数。
  * @returns {Promise<{
  *   audioUrl: string,
  *   mouthTimeline: TimelinePoint[],
@@ -444,6 +444,9 @@ export const requestServerTts = async (text, options = {}) => {
   if (options.voice) params.set('voice', options.voice);
   if (options.rate) params.set('rate', String(options.rate));
   if (options.provider) params.set('provider', options.provider);
+  if (Number.isFinite(options.segmentIndex)) params.set('segmentIndex', String(options.segmentIndex));
+  if (Number.isFinite(options.segmentCount)) params.set('segmentCount', String(options.segmentCount));
+  if (options.segmentId) params.set('segmentId', options.segmentId);
   const response = await fetch(resolveServerUrl(`/tts?${params.toString()}`), {
     method: 'GET',
     signal: options.abortSignal,


### PR DESCRIPTION
## Summary
- add an in-memory `/tts` cache with TTL, LRU eviction and pending-request de-duplication, plus expose cache stats in metrics
- extend the web TimelinePlayer with segmented prefetching, configurable latency compensation and shared playback clock helpers
- document the new cache knobs and playback preferences for both server and web modules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4e903b483289ddac75b894110a0