### PR TITLE
feat(theme): add unified JSON-based theming across web and weapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,49 @@ npm run dev
 
 可按需增加更多角色（至少保留一个 `default`），修改后无需重启前端即可生效。
 
+## 主题系统
+
+- 根目录 `themes/` 存放纯 JSON 主题与 `manifest.json`：
+  - `manifest.json` 指定默认主题 ID，并列出每个主题文件的相对路径；
+  - 单个主题 JSON 支持如下字段：
+
+    ```json
+    {
+      "id": "dark",
+      "name": "午夜霓虹",
+      "bg": "#0f172a",
+      "stroke": "#e2e8f0",
+      "fill": "#1e293b",
+      "lineWidth": 6,
+      "body": { "stroke": "#e2e8f0", "lineWidth": 6 },
+      "head": { "stroke": "#38bdf8", "fill": "#1e293b", "lineWidth": 5 },
+      "eye": { "stroke": "#38bdf8", "lineWidth": 4, "gap": 22, "minHeight": 1.5 },
+      "mouth": {
+        "stroke": "#0ea5e9",
+        "lineWidth": 5.5,
+        "fill": "#082f49",
+        "innerFill": "#082f49",
+        "toothFill": "#bae6fd",
+        "toothCount": 4,
+        "toothScale": 0.9,
+        "widthScale": 0.95,
+        "heightScale": 1.05,
+        "cornerCurveBase": 0.04,
+        "highlightStroke": "#38bdf8",
+        "highlightWidth": 1.8,
+        "roundedViseme": 10
+      }
+    }
+    ```
+
+  - `bg` 为画布背景色，`stroke`/`fill`/`lineWidth` 提供全局默认描边与线宽；
+  - `body`、`head`、`eye` 可覆盖对应部位的颜色与线宽；
+  - `mouth` 控制嘴部细节，包括宽高缩放、牙齿数量/颜色、嘴角基础弧度、圆唇高光、指定与高光相关的 `roundedViseme`；
+  - 数值字段会在运行时自动夹紧（如线宽至少 1px、缩放范围 0.4~2.2），避免异常配置导致绘制溢出。
+- Express 服务端会自动通过 `/themes` 暴露这些 JSON 文件，网页端与小程序首先读取 `manifest.json`，再按 `path` 拉取主题内容。
+- 主题选择优先级：**页面手动选择 > 角色档案默认值 > Manifest 默认主题**，两端的渲染逻辑保持一致；若本地缓存的主题已被移除，将回退到默认主题并清除缓存。
+- 新增主题只需在 `themes/` 中放置 JSON 文件并更新 `manifest.json`，无需重新构建即可在 web 与 weapp 端生效。
+
 ## 语义表情触发词典
 
 - `packages/stickbot-core/src/emotion/semantic-triggers.ts` 内置 `deriveSemanticTimelines`，会根据文本、`estimateSentiment` 结果与 `wordTimeline` 推导 `emoteTimeline`、`gestureTimeline`；

--- a/packages/stickbot-core/src/index.ts
+++ b/packages/stickbot-core/src/index.ts
@@ -3,8 +3,16 @@
  * 核心导出：包含 Avatar、时间线播放器与情绪工具。
  */
 
-export { BigMouthAvatar, DEFAULT_CONFIG } from './avatar.bigmouth.js';
-export type { AvatarConfig, MouthFrame, RenderMode, SpriteOptions } from './avatar.bigmouth.js';
+export { BigMouthAvatar, DEFAULT_CONFIG, DEFAULT_THEME } from './avatar.bigmouth.js';
+export type {
+  AvatarConfig,
+  AvatarInitOptions,
+  AvatarTheme,
+  AvatarThemeResolved,
+  MouthFrame,
+  RenderMode,
+  SpriteOptions,
+} from './avatar.bigmouth.js';
 
 export { TimelinePlayer } from './timeline-player.js';
 export type {

--- a/server/server.js
+++ b/server/server.js
@@ -327,6 +327,11 @@ app.use(helmet());
 app.use(express.json({ limit: '10kb' }));
 app.use(express.urlencoded({ extended: false, limit: '10kb' }));
 
+const themesDir = path.resolve(process.cwd(), 'themes');
+if (fs.existsSync(themesDir)) {
+  app.use('/themes', express.static(themesDir, { extensions: ['json'] }));
+}
+
 /**
  * 本地开发默认允许任意来源跨域，生产环境可在 .env 中配置白名单。
  */

--- a/themes/bright.json
+++ b/themes/bright.json
@@ -1,0 +1,38 @@
+{
+  "id": "bright",
+  "name": "暖阳活力",
+  "bg": "#fff7ed",
+  "lineWidth": 6,
+  "stroke": "#7c2d12",
+  "fill": "#fffaf0",
+  "body": {
+    "stroke": "#7c2d12",
+    "lineWidth": 6
+  },
+  "head": {
+    "stroke": "#9a3412",
+    "fill": "#fffaf0",
+    "lineWidth": 5
+  },
+  "eye": {
+    "stroke": "#9a3412",
+    "lineWidth": 4,
+    "gap": 22,
+    "minHeight": 2
+  },
+  "mouth": {
+    "stroke": "#ea580c",
+    "lineWidth": 6,
+    "fill": "#c2410c",
+    "innerFill": "#c2410c",
+    "toothFill": "#fffbeb",
+    "toothCount": 5,
+    "toothScale": 1.1,
+    "widthScale": 1.05,
+    "heightScale": 1.1,
+    "cornerCurveBase": 0.08,
+    "highlightStroke": "#fb923c",
+    "highlightWidth": 2,
+    "roundedViseme": 8
+  }
+}

--- a/themes/classic.json
+++ b/themes/classic.json
@@ -1,0 +1,38 @@
+{
+  "id": "classic",
+  "name": "经典紫调",
+  "bg": "#f5f5f5",
+  "lineWidth": 6,
+  "stroke": "#1f2937",
+  "fill": "#f3f4ff",
+  "body": {
+    "stroke": "#1f2937",
+    "lineWidth": 6
+  },
+  "head": {
+    "stroke": "#312e81",
+    "fill": "#f3f4ff",
+    "lineWidth": 5
+  },
+  "eye": {
+    "stroke": "#312e81",
+    "lineWidth": 4,
+    "gap": 20,
+    "minHeight": 2
+  },
+  "mouth": {
+    "stroke": "#7c3aed",
+    "lineWidth": 6,
+    "fill": "#4c1d95",
+    "innerFill": "#4c1d95",
+    "toothFill": "#ede9fe",
+    "toothCount": 6,
+    "toothScale": 1,
+    "widthScale": 1,
+    "heightScale": 1,
+    "cornerCurveBase": 0.1,
+    "highlightStroke": "#a855f7",
+    "highlightWidth": 2,
+    "roundedViseme": 9
+  }
+}

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -1,0 +1,38 @@
+{
+  "id": "dark",
+  "name": "午夜霓虹",
+  "bg": "#0f172a",
+  "lineWidth": 6,
+  "stroke": "#e2e8f0",
+  "fill": "#1e293b",
+  "body": {
+    "stroke": "#e2e8f0",
+    "lineWidth": 6
+  },
+  "head": {
+    "stroke": "#38bdf8",
+    "fill": "#1e293b",
+    "lineWidth": 5
+  },
+  "eye": {
+    "stroke": "#38bdf8",
+    "lineWidth": 4,
+    "gap": 22,
+    "minHeight": 1.5
+  },
+  "mouth": {
+    "stroke": "#0ea5e9",
+    "lineWidth": 5.5,
+    "fill": "#082f49",
+    "innerFill": "#082f49",
+    "toothFill": "#bae6fd",
+    "toothCount": 4,
+    "toothScale": 0.9,
+    "widthScale": 0.95,
+    "heightScale": 1.05,
+    "cornerCurveBase": 0.04,
+    "highlightStroke": "#38bdf8",
+    "highlightWidth": 1.8,
+    "roundedViseme": 10
+  }
+}

--- a/themes/manifest.json
+++ b/themes/manifest.json
@@ -1,0 +1,9 @@
+{
+  "default": "classic",
+  "themes": [
+    { "id": "classic", "name": "经典紫调", "path": "./classic.json" },
+    { "id": "bright", "name": "暖阳活力", "path": "./bright.json" },
+    { "id": "dark", "name": "午夜霓虹", "path": "./dark.json" },
+    { "id": "minimal", "name": "极简线条", "path": "./minimal.json" }
+  ]
+}

--- a/themes/minimal.json
+++ b/themes/minimal.json
@@ -1,0 +1,38 @@
+{
+  "id": "minimal",
+  "name": "极简线条",
+  "bg": "#fdfdfc",
+  "lineWidth": 5,
+  "stroke": "#1a1a1a",
+  "fill": "#ffffff",
+  "body": {
+    "stroke": "#1a1a1a",
+    "lineWidth": 5
+  },
+  "head": {
+    "stroke": "#1a1a1a",
+    "fill": "#ffffff",
+    "lineWidth": 4.5
+  },
+  "eye": {
+    "stroke": "#111111",
+    "lineWidth": 3,
+    "gap": 18,
+    "minHeight": 1.5
+  },
+  "mouth": {
+    "stroke": "#1f2937",
+    "lineWidth": 4.5,
+    "fill": "#111111",
+    "innerFill": "#111111",
+    "toothFill": "#f4f4f5",
+    "toothCount": 4,
+    "toothScale": 0.8,
+    "widthScale": 0.9,
+    "heightScale": 0.85,
+    "cornerCurveBase": 0,
+    "highlightStroke": "#52525b",
+    "highlightWidth": 1.5,
+    "roundedViseme": 7
+  }
+}

--- a/weapp-stickbot/README.md
+++ b/weapp-stickbot/README.md
@@ -19,6 +19,19 @@
 - 当前选择会写入 `wx.setStorageSync('stickbot:role-profile')`，下次打开自动恢复；
 - 若服务端暂未提供档案，则回退到仓库内置的 `default/energetic/soft` 示例，可在 `roles/` 中自由增删。
 
+## 主题 JSON 与手动切换
+
+- 小程序与网页共用根目录 `themes/manifest.json` 与 `themes/*.json`：
+  - `manifest.json` 提供默认主题 ID 与各主题文件路径；
+  - 主题 JSON 支持 `bg`、`stroke`、`fill`、`lineWidth` 以及 `body`、`head`、`eye`、`mouth` 的细化字段；
+  - `mouth` 字段可配置牙齿数量/颜色、宽高缩放、嘴角基准弧度、圆唇高光以及 `roundedViseme` 对应的高光口型；
+  - 超出合理范围的数值会被运行时夹紧，例如线宽至少 1 像素、缩放范围 0.4~2.2。
+- 首页新增“主题风格”选择器：
+  - 手动选择的主题写入 `wx.setStorageSync('stickbot:manual-theme')`，优先级高于角色档案内的 `theme` 字段；
+  - 选择“跟随角色”时会清除手动偏好，回退到角色默认或 `manifest` 默认主题；
+  - 若本地缓存主题在 manifest 中已不存在，页面会自动回退到默认主题并移除缓存。
+- 服务端启动后会通过 `/themes` 静态路由暴露所有主题 JSON，真机调试需保证域名在微信后台合法域名列表中。
+
 ## 使用步骤
 
 1. 在小程序管理后台添加合法域名（开发环境可勾选“开发阶段忽略”），确保包含 `http://localhost:8787` 或部署地址。

--- a/weapp-stickbot/pages/index/index.wxml
+++ b/weapp-stickbot/pages/index/index.wxml
@@ -22,6 +22,12 @@
         <view class="picker-value">{{renderModes[renderModeIndex]}}</view>
       </picker>
     </view>
+    <view class="selector">
+      <text class="label">主题风格</text>
+      <picker mode="selector" range="{{themeNames}}" value="{{themeIndex}}" bindchange="onThemeChange">
+        <view class="picker-value">{{themeNames.length ? themeNames[themeIndex] : ''}}</view>
+      </picker>
+    </view>
     <view class="switch-row">
       <text class="label">自动增益</text>
       <switch checked="{{autoGainEnabled}}" bindchange="onAutoGainToggle"></switch>

--- a/weapp-stickbot/pages/index/index.wxss
+++ b/weapp-stickbot/pages/index/index.wxss
@@ -105,6 +105,40 @@
   box-shadow: 0 16px 30px rgba(17, 24, 39, 0.18);
 }
 
+.container.theme-classic {
+  background: #f5f5f5;
+  color: #1f2937;
+}
+
+.container.theme-classic .panel {
+  background: #ffffff;
+  color: #1f2937;
+  box-shadow: 0 14px 30px rgba(79, 70, 229, 0.16);
+}
+
+.container.theme-classic .picker-value {
+  background: #ede9fe;
+  color: #312e81;
+}
+
+.container.theme-classic .role-description,
+.container.theme-classic .role-meta,
+.container.theme-classic .info,
+.container.theme-classic .hint {
+  color: #4338ca;
+}
+
+.container.theme-classic .avatar-canvas {
+  background: #f3f4ff;
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.2);
+}
+
+.container.theme-classic .subtitle-bar {
+  background: linear-gradient(135deg, #4c1d95, #7c3aed);
+  color: #ede9fe;
+  box-shadow: 0 18px 36px rgba(124, 58, 237, 0.25);
+}
+
 .container.theme-bright {
   background: #fff7ed;
   color: #7c2d12;
@@ -139,70 +173,70 @@
   box-shadow: 0 16px 32px rgba(234, 88, 12, 0.22);
 }
 
-.container.theme-pastel {
-  background: #f3e8ff;
-  color: #4c1d95;
-}
-
-.container.theme-pastel .panel {
-  background: #fdf4ff;
-  color: #4c1d95;
-  box-shadow: 0 14px 30px rgba(147, 51, 234, 0.18);
-}
-
-.container.theme-pastel .picker-value {
-  background: #f8e8ff;
-  color: #6d28d9;
-}
-
-.container.theme-pastel .role-description,
-.container.theme-pastel .role-meta,
-.container.theme-pastel .info,
-.container.theme-pastel .hint {
-  color: #7c3aed;
-}
-
-.container.theme-pastel .avatar-canvas {
-  background: #fdf4ff;
-  box-shadow: 0 14px 28px rgba(147, 51, 234, 0.16);
-}
-
-.container.theme-pastel .subtitle-bar {
-  background: linear-gradient(135deg, #a855f7, #7c3aed);
-  color: #fdf4ff;
-  box-shadow: 0 16px 32px rgba(124, 58, 237, 0.22);
-}
-
-.container.theme-noir {
+.container.theme-dark {
   background: #0f172a;
   color: #e2e8f0;
 }
 
-.container.theme-noir .panel {
+.container.theme-dark .panel {
   background: #1e293b;
   color: #e2e8f0;
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.6);
 }
 
-.container.theme-noir .picker-value {
+.container.theme-dark .picker-value {
   background: #1f2937;
-  color: #bae6fd;
+  color: #38bdf8;
 }
 
-.container.theme-noir .role-description,
-.container.theme-noir .role-meta,
-.container.theme-noir .info,
-.container.theme-noir .hint {
+.container.theme-dark .role-description,
+.container.theme-dark .role-meta,
+.container.theme-dark .info,
+.container.theme-dark .hint {
   color: #94a3b8;
 }
 
-.container.theme-noir .avatar-canvas {
+.container.theme-dark .avatar-canvas {
   background: #1e293b;
   box-shadow: 0 18px 38px rgba(15, 23, 42, 0.6);
 }
 
-.container.theme-noir .subtitle-bar {
+.container.theme-dark .subtitle-bar {
   background: linear-gradient(135deg, #0ea5e9, #0369a1);
   color: #0f172a;
   box-shadow: 0 18px 38px rgba(14, 165, 233, 0.28);
+}
+
+.container.theme-minimal {
+  background: #fdfdfc;
+  color: #1f2937;
+}
+
+.container.theme-minimal .panel {
+  background: #ffffff;
+  color: #1f2937;
+  box-shadow: 0 12px 26px rgba(17, 24, 39, 0.12);
+}
+
+.container.theme-minimal .picker-value {
+  background: #f5f5f4;
+  color: #1a1a1a;
+}
+
+.container.theme-minimal .role-description,
+.container.theme-minimal .role-meta,
+.container.theme-minimal .info,
+.container.theme-minimal .hint {
+  color: #4b5563;
+}
+
+.container.theme-minimal .avatar-canvas {
+  background: #ffffff;
+  box-shadow: 0 12px 24px rgba(17, 24, 39, 0.12);
+}
+
+.container.theme-minimal .subtitle-bar {
+  background: linear-gradient(135deg, #1f2937, #4b5563);
+  color: #f8fafc;
+  box-shadow: 0 16px 30px rgba(30, 41, 59, 0.18);
 }

--- a/web/README.md
+++ b/web/README.md
@@ -25,6 +25,16 @@
 - 档案存放于仓库根目录 `roles/`，可随时新增/修改，浏览器会在刷新后读取；
 - 浏览器会将最近一次选择保存在 `localStorage`，再次进入页面时自动恢复。
 
+### 主题 JSON 与扩展
+
+- 网页主题配置统一放置在仓库根目录 `themes/` 下，由 `manifest.json` 描述默认主题与各主题文件：
+  - `manifest.json` 字段包括 `default`（默认主题 ID）与 `themes` 数组，数组项需包含 `id`、`name` 与 `path`；
+  - 主题 JSON 支持 `bg`、`stroke`、`fill`、`lineWidth` 等顶层样式，以及 `body`、`head`、`eye`、`mouth` 的子对象；
+  - `mouth` 可进一步指定 `toothCount`、`toothScale`、`widthScale`、`heightScale`、`cornerCurveBase`、`highlightStroke`、`highlightWidth` 与 `roundedViseme` 等细节；
+  - 数值字段会在运行时自动归一并夹紧，非法输入将回退到默认主题对应值。
+- `main.js` 会先加载 `manifest.json`，再按 `path` 拉取主题 JSON 并注册到选择器；手动选择的主题写入 `localStorage('stickbot:manual-theme')`，优先级高于角色默认。
+- 若主题文件删除或字段缺失，页面会自动回退到 `manifest` 默认主题，并清除失效的本地偏好。
+
 ## 口型驱动优先级
 
 1. **服务端时间轴**：`/tts` 返回 `mouthTimeline` 时，`main.js` 会创建 `<audio>` 元素播放 `audioUrl`，同时调用 `MouthSignal.playTimeline`，以 ~80Hz 的关键帧驱动嘴唇开合。

--- a/web/index.html
+++ b/web/index.html
@@ -127,6 +127,11 @@
         color: var(--card-text);
       }
 
+      .selector-hint {
+        font-size: 12px;
+        color: var(--hint-text);
+      }
+
       .role-description {
         margin: 0;
         font-size: 13px;
@@ -280,7 +285,7 @@
         --chip-active-shadow: 0 6px 16px rgba(234, 88, 12, 0.28);
       }
 
-      body.theme-noir {
+      body.theme-dark {
         --page-bg: #0f172a;
         --page-text: #e2e8f0;
         --card-bg: #1e293b;
@@ -302,26 +307,26 @@
         --chip-active-shadow: 0 8px 22px rgba(14, 165, 233, 0.38);
       }
 
-      body.theme-pastel {
-        --page-bg: #f3e8ff;
-        --page-text: #4c1d95;
-        --card-bg: #fdf4ff;
-        --card-text: #4c1d95;
-        --card-shadow: 0 12px 32px rgba(76, 29, 149, 0.12);
-        --card-border: rgba(192, 132, 252, 0.35);
-        --accent-bg: #a855f7;
-        --accent-text: #fdf4ff;
-        --secondary-bg: #e9d5ff;
-        --secondary-text: #4c1d95;
-        --hint-text: #7c3aed;
-        --timeline-bg: rgba(253, 244, 255, 0.88);
-        --timeline-border: rgba(192, 132, 252, 0.4);
-        --input-border: rgba(167, 85, 247, 0.4);
-        --chip-bg: rgba(167, 85, 247, 0.14);
-        --chip-text: #6d28d9;
-        --chip-active-bg: #9333ea;
-        --chip-active-text: #fdf4ff;
-        --chip-active-shadow: 0 6px 18px rgba(147, 51, 234, 0.32);
+      body.theme-minimal {
+        --page-bg: #f5f5f4;
+        --page-text: #1f2937;
+        --card-bg: #ffffff;
+        --card-text: #1f2937;
+        --card-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+        --card-border: rgba(31, 41, 55, 0.1);
+        --accent-bg: #111827;
+        --accent-text: #f9fafb;
+        --secondary-bg: #e5e7eb;
+        --secondary-text: #1f2937;
+        --hint-text: #4b5563;
+        --timeline-bg: #f8fafc;
+        --timeline-border: #e2e8f0;
+        --input-border: #d1d5db;
+        --chip-bg: rgba(17, 24, 39, 0.08);
+        --chip-text: #111827;
+        --chip-active-bg: #1f2937;
+        --chip-active-text: #f8fafc;
+        --chip-active-shadow: 0 6px 16px rgba(17, 24, 39, 0.25);
       }
     </style>
   </head>
@@ -336,6 +341,11 @@
           <select id="role-select"></select>
           <p class="role-description" id="role-description">选择不同角色，stickbot 将切换 voice、表情预设与主题皮肤。</p>
           <p class="role-meta" id="role-meta"></p>
+        </div>
+        <div class="selector-group">
+          <label for="theme-select">主题皮肤</label>
+          <select id="theme-select"></select>
+          <small class="selector-hint">页面选择优先级最高，可覆盖角色默认主题。</small>
         </div>
         <div class="selector-group">
           <label for="tts-provider">TTS 供应器</label>


### PR DESCRIPTION
## Summary
- add shared JSON theme files with a manifest served via `/themes`
- update core, web, and weapp renderers to resolve theme styles and expose a manual selector
- document the JSON schema and priority rules for theme overrides in the READMEs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcaac597dc83289ccf1c5649d6da0f